### PR TITLE
Allow for filtering by metadata fields

### DIFF
--- a/src/types/codegen.ts
+++ b/src/types/codegen.ts
@@ -51,7 +51,9 @@ export namespace RONIN {
         ? BooleanFilterFunction<T, R>
         : T extends Date
           ? DateFilterFunction<T, R>
-          : never;
+          : T extends Record<string, any>
+            ? { [K in keyof T]: FilterFunction<T[K], R> }
+            : never;
 
   type FilterObject<T> = T extends string
     ?
@@ -142,7 +144,9 @@ export namespace RONIN {
               }
         : T extends boolean
           ? { being: boolean }
-          : never;
+          : T extends Record<string, any>
+            ? { [K in keyof T]: T[K] | Partial<FilterObject<T[K]>> }
+            : never;
 
   export type WithObject<TSchema, R, P = undefined> = {
     [K in keyof TSchema]: P extends undefined

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -152,5 +152,7 @@ export const toDashCase = (string?: string | null): string => {
  * @param timeFields - An array of property keys for the time fields.
  */
 export const formatTimeFields = (record: object, timeFields: string[]) => {
-  timeFields.forEach((field) => setProperty(record, field, (value: string) => new Date(value)));
+  timeFields.forEach((field) =>
+    setProperty(record, field, (value: string | null) => (value !== null ? new Date(value) : null)),
+  );
 };


### PR DESCRIPTION
Makes it possible to filter by `ronin` metadata fields.

For example: 

```typescript
get.account.with.ronin.createdAt(new Date());
get.account.with.ronin.createdAt.lessThan(new Date());
```