### PR TITLE
Create Git Tag when publishing to npm

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -8,6 +8,7 @@ inputs:
   package_dir:
     description: Directory of the Package to Publish
     required: true
+    default: './'
 
 outputs:
   VERSION_TAG:

--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -27,13 +27,6 @@ runs:
         echo "VERSION_TAG=$(echo $BRANCH_NAME)-experimental" >> $GITHUB_ENV
         echo "VERSION_TAG=$(echo $VERSION_TAG)" >> $GITHUB_OUTPUT
 
-    - name: Configure Git
-      shell: bash
-      run: |
-        # See where these config values come from at https://stackoverflow.com/a/74071223
-        git config --global user.name "ronin-app[bot]"
-        git config --global user.email 135042755+ronin-app[bot]@users.noreply.github.com
-
     - name: Bump ${{ inputs.package_dir }}
       shell: bash
       run: |
@@ -51,11 +44,11 @@ runs:
         # Check if the experimental version already exists
         if ! echo "$ALL_VERSIONS" | grep -q "$REGEX"; then
           # If not, create it
-          npm version prerelease --preid=$VERSION_TAG
+          npm version prerelease --preid=$VERSION_TAG --no-git-tag-version
         else
           # Otherwise up it
           LATEST_VERSION=$(echo "$ALL_VERSIONS" | grep "$REGEX" | tail -1)
-          npm version $(npx semver $LATEST_VERSION -i prerelease --preid="$VERSION_TAG")
+          npm version $(npx semver $LATEST_VERSION -i prerelease --preid="$VERSION_TAG") --no-git-tag-version
         fi
 
     - name: Publish to npm

--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -26,6 +26,13 @@ runs:
         echo "VERSION_TAG=$(echo $BRANCH_NAME)-experimental" >> $GITHUB_ENV
         echo "VERSION_TAG=$(echo $VERSION_TAG)" >> $GITHUB_OUTPUT
 
+    - name: Configure Git
+      shell: bash
+      run: |
+        # See where these config values come from at https://stackoverflow.com/a/74071223
+        git config --global user.name "ronin-app[bot]"
+        git config --global user.email 135042755+ronin-app[bot]@users.noreply.github.com
+
     - name: Bump ${{ inputs.package_dir }}
       shell: bash
       run: |

--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -43,11 +43,11 @@ runs:
         # Check if the experimental version already exists
         if ! echo "$ALL_VERSIONS" | grep -q "$REGEX"; then
           # If not, create it
-          npm version prerelease --preid=$VERSION_TAG --no-git-tag-version
+          npm version prerelease --preid=$VERSION_TAG
         else
           # Otherwise up it
           LATEST_VERSION=$(echo "$ALL_VERSIONS" | grep "$REGEX" | tail -1)
-          npm version $(npx semver $LATEST_VERSION -i prerelease --preid="$VERSION_TAG") --no-git-tag-version
+          npm version $(npx semver $LATEST_VERSION -i prerelease --preid="$VERSION_TAG")
         fi
 
     - name: Publish to npm

--- a/.github/workflows/publish-experimental.yml
+++ b/.github/workflows/publish-experimental.yml
@@ -36,8 +36,6 @@ jobs:
       - name: Bump `ronin`
         id: bump-ronin
         uses: ./.github/actions/bump-version
-        with:
-          package_dir: ./
 
       - name: Comment on PR
         uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -52,13 +52,20 @@ jobs:
           git config --global user.email 135042755+ronin-app[bot]@users.noreply.github.com
 
       - name: Bump `ronin`
-        run: npm version ${{ inputs.version_type }}
+        run: |
+          npm version ${{ inputs.version_type }} --git-tag-version=false
+          echo "NEW_VERSION=$(npm pkg get version --workspaces=false | tr -d \")" >> $GITHUB_ENV
 
       - name: Push New Version
         run: |
           git fetch
           git checkout ${GITHUB_HEAD_REF}
+          git pull origin ${GITHUB_HEAD_REF}
+          git commit -a -m '${{ env.NEW_VERSION }}' --no-verify
+          git tag -a ${{ env.NEW_VERSION }} -m '${{ env.NEW_VERSION }}'
           git push origin ${GITHUB_HEAD_REF}
+          # Push tag
+          git push origin ${{ env.NEW_VERSION }}
 
       - name: Publish npm Package
         run: npm publish


### PR DESCRIPTION
Creates a Git Tag when publishing to npm, which helps us with creating releases.