### PR TITLE
Stop hiding upload errors

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -81,9 +81,7 @@ export const uploadStorableObjects = async (
     });
 
     const response = await fetcher(request);
-
-    if (!response.ok) throw new Error('An unexpected error occurred while uploading the object.');
-
+    if (!response.ok) throw new Error(await response.text());
     return response.json() as Promise<StoredObject>;
   });
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -86,7 +86,7 @@ export const uploadStorableObjects = async (
   });
 
   return Promise.all(requests).catch((err) => {
-    const message = `An error occurred while uploading the binary objects included in the provided queries: ${err}`;
+    const message = `An error occurred while uploading the binary objects included in the provided queries. ${err}`;
     throw new Error(message);
   });
 };

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -87,12 +87,8 @@ export const uploadStorableObjects = async (
     return response.json() as Promise<StoredObject>;
   });
 
-  return Promise.all(requests).catch(() => {
-    const message =
-      requests.length === 1
-        ? `An unexpected error occurred while uploading the object. Please try again.`
-        : `An unexpected error occurred while uploading one or more objects. Please try again.`;
-
+  return Promise.all(requests).catch((err) => {
+    const message = `An error occurred while uploading the binary objects included in the provided queries: ${err}`;
     throw new Error(message);
   });
 };

--- a/tests/integration/factory.test.ts
+++ b/tests/integration/factory.test.ts
@@ -416,7 +416,9 @@ describe('factory', () => {
     const factory = createSyntaxFactory({
       fetch: async (request) => {
         if ((request as Request).url === 'https://storage.ronin.co/') {
-          return Response.error();
+          return new Response('Details here', {
+            status: 403,
+          });
         }
         return mockFetch(request);
       },
@@ -428,7 +430,9 @@ describe('factory', () => {
       },
     });
 
-    expect(promise).rejects.toThrow('An unexpected error occurred while uploading the object.');
+    expect(promise).rejects.toThrow(
+      'An error occurred while uploading the binary objects included in the provided queries. Error: Details here',
+    );
   });
 
   test('format time fields', async () => {


### PR DESCRIPTION
If an error occurs during upload (e.g. if a file doesn't exist), we're hiding the original error.

This change ensures that the error is shown!