### PR TITLE
Do not provide a default `Content-Type`

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -83,7 +83,7 @@ export const uploadStorableObjects = async (
       headers.set('Content-Type', contentType);
     }
 
-    const request = new Request('http://localhost:5001/', {
+    const request = new Request('https://storage.ronin.co/', {
       method: 'PUT',
       body: value,
       headers,

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -38,19 +38,21 @@ export const extractStorableObjects = (queries: Query[]): StorableObject[] =>
 
                 if (!isStorableObject) return references;
 
-                return [
-                  ...references,
-                  {
-                    query: {
-                      index: queryIndex,
-                      type: queryType,
-                    },
-                    schema,
-                    field: name,
-                    value,
-                    contentType: 'type' in value ? value.type : 'application/octet-stream',
+                const storarableObject = {
+                  query: {
+                    index: queryIndex,
+                    type: queryType,
                   },
-                ];
+                  schema,
+                  field: name,
+                  value,
+                } as StorableObject;
+
+                if ('type' in value) {
+                  storarableObject.contentType = value.type;
+                }
+
+                return [...references, storarableObject];
               }, [] as any[]),
             ];
           }, [] as StorableObject[]),
@@ -74,10 +76,17 @@ export const uploadStorableObjects = async (
   const fetcher = typeof options?.fetch === 'function' ? options.fetch : fetch;
 
   const requests: Promise<StoredObject>[] = storableObjects.map(async ({ value, contentType }) => {
-    const request = new Request('https://storage.ronin.co/', {
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${options.token}`);
+
+    if (contentType) {
+      headers.set('Content-Type', contentType);
+    }
+
+    const request = new Request('http://localhost:5001/', {
       method: 'PUT',
       body: value,
-      headers: { 'Content-Type': contentType, Authorization: `Bearer ${options.token}` },
+      headers,
     });
 
     const response = await fetcher(request);

--- a/src/types/codegen.ts
+++ b/src/types/codegen.ts
@@ -1,4 +1,4 @@
-import type { StorableObjectValue, StoredObject } from './/storage';
+import type { StorableObjectValue, StoredObject } from './storage';
 import type { ReducedFunction, ReplaceRecursively } from './utils';
 
 export namespace RONIN {

--- a/src/types/codegen.ts
+++ b/src/types/codegen.ts
@@ -1,4 +1,6 @@
-import type { ReducedFunction } from './utils';
+import type { StorableObjectValue } from 'src/types/storage';
+
+import type { ReducedFunction, ReplaceRecursively } from './utils';
 
 export namespace RONIN {
   export interface RoninRecord<TId extends string = string> {
@@ -15,6 +17,25 @@ export namespace RONIN {
     status: 'draft' | 'published' | 'archived';
     updatedAt: Date;
     updatedBy: Record<string, any>;
+  }
+
+  export interface Blob {
+    key: string;
+    meta:
+      | {
+          size: number;
+          type: string;
+        }
+      | {
+          size: number;
+          type: string;
+          width: number;
+          height: number;
+        };
+    placeholder: {
+      base64: string;
+    } | null;
+    src: string;
   }
 
   interface StringFilterFunction<T, R> extends ReducedFunction {
@@ -239,14 +260,17 @@ export namespace RONIN {
   export interface ISetter<TSchema, TReturn, TVariant extends string = string> extends ReducedFunction {
     (filter: {
       with: Partial<WithObject<TSchema, TReturn, true>>;
-      to: Partial<TSchema>;
+      to: Partial<ReplaceRecursively<TSchema, RONIN.Blob, StorableObjectValue>>;
       in?: TVariant;
     }): Promise<TReturn>;
   }
 
   export interface ICreator<TSchema, TReturn, TVariant extends string = string> extends ReducedFunction {
-    (filter?: { with: Partial<TSchema>; in?: TVariant }): Promise<TReturn>;
-    with: (values: Partial<TSchema>) => Promise<TReturn>;
+    (filter?: {
+      with: Partial<ReplaceRecursively<TSchema, RONIN.Blob, StorableObjectValue>>;
+      in?: TVariant;
+    }): Promise<TReturn>;
+    with: (values: Partial<ReplaceRecursively<TSchema, RONIN.Blob, StorableObjectValue>>) => Promise<TReturn>;
   }
 
   export interface ICounter<TSchema, TVariant extends string = string, TWith = With<TSchema, number>>

--- a/src/types/codegen.ts
+++ b/src/types/codegen.ts
@@ -1,5 +1,4 @@
-import type { StorableObjectValue } from 'src/types/storage';
-
+import type { StorableObjectValue, StoredObject } from './/storage';
 import type { ReducedFunction, ReplaceRecursively } from './utils';
 
 export namespace RONIN {
@@ -19,24 +18,7 @@ export namespace RONIN {
     updatedBy: Record<string, any>;
   }
 
-  export interface Blob {
-    key: string;
-    meta:
-      | {
-          size: number;
-          type: string;
-        }
-      | {
-          size: number;
-          type: string;
-          width: number;
-          height: number;
-        };
-    placeholder: {
-      base64: string;
-    } | null;
-    src: string;
-  }
+  export interface Blob extends StoredObject {}
 
   interface StringFilterFunction<T, R> extends ReducedFunction {
     (value: T): Promise<R>;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -41,4 +41,4 @@ export type StoredObject = {
       };
 };
 
-export type StorableObjectValue = File | ReadableStream | Buffer;
+export type StorableObjectValue = File | ReadableStream | Buffer | ArrayBuffer | Blob;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -86,3 +86,13 @@ export interface ReducedFunction extends Function {
    */
   arguments: never;
 }
+
+type ReplaceIfExtends<TValue, TType, TReplacement> = TValue extends TType ? TReplacement : TValue;
+
+export type ReplaceRecursively<TValue, TType, TReplacement> = {
+  [K in keyof TValue]: TValue[K] extends TType
+    ? ReplaceIfExtends<TValue[K], TType, TReplacement>
+    : TValue[K] extends object
+      ? ReplaceRecursively<TValue[K], TType, TReplacement>
+      : TValue[K];
+};


### PR DESCRIPTION
Closes RON-917.

Changes:
- Do not provide the server with a default `Content-Type` header if we cannot extract it from the given storable value
- Improve the types for setting a blob property when creating or setting a record with a blob field