### PR TITLE
Group all dependencies into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,9 @@ updates:
 
     labels:
       - 'enhancement'
+
+    # Create one pull request for all dependencies.
+    groups:
+      all:
+        patterns:
+          - '*'


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/client/pull/30 and truly ensures a single Dependabot PR per week!