### PR TITLE
Simplify Blob's meta type

### DIFF
--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -5,17 +5,12 @@ export type StoredObject = {
   placeholder: {
     base64: string | null;
   } | null;
-  meta:
-    | {
-        size: number;
-        type: string;
-      }
-    | {
-        size: number;
-        type: string;
-        width: number;
-        height: number;
-      };
+  meta: {
+    size: number;
+    type: string;
+    width?: number;
+    height?: number;
+  };
 };
 
 export type StorableObject = {


### PR DESCRIPTION
Based on the feedback we've received from our customers, currently accessing the `width` and `height` propery of the meta field throws a TS error pointing out that these properties do not exist. That's because we're using a union type for the `meta` property where one union does not include the `width` and `height` at all.

So we're making the `width` and `height` properties rather optional (`?`) so you can still access them without any workarounds (e.g. `'width' in blob.meta && blob.meta.width`).