### PR TITLE
Consider `RONIN_TOKEN` env var in CLI

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -46,24 +46,26 @@ const run = async () => {
   if (values.help) return printHelp();
   if (values.version) return printVersion();
 
+  // This ensures that people can accidentally type uppercase letters and still
+  // get the command they are looking for.
+  const normalizedPositionals = positionals.map((positional) => positional.toLowerCase());
+
   // If this environment variable is provided, the CLI will authenticate as an
   // app for a particular space instead of authenticating as an account. This
   // is especially useful in CI, which must be independent of a team member.
   const appToken = process.env.RONIN_TOKEN;
 
   // If there is no active session, automatically start one and then continue
-  // with the execution of the requested sub command, if there is one.
+  // with the execution of the requested sub command, if there is one. If the
+  // `login` sub command is invoked, we don't need to auto-login, since the
+  // command itself will handle it already.
   const session = await getSession();
-  if (!session) await logIn(appToken);
+  if (!session && !normalizedPositionals.includes('login')) await logIn(appToken);
 
-  // This ensures that people can accidentally type uppercase letters and still
-  // get the command they are looking for.
-  const normalizedPositionals = positionals.map((positional) => positional.toLowerCase());
-
-  // `login` command
+  // `login` sub command
   if (normalizedPositionals.includes('login')) return logIn(appToken);
 
-  // `init` command
+  // `init` sub command
   if (normalizedPositionals.includes('init')) return initializeProject(positionals);
 
   // If no matching flags or commands were found, render the help, since we

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -46,17 +46,22 @@ const run = async () => {
   if (values.help) return printHelp();
   if (values.version) return printVersion();
 
+  // If this environment variable is provided, the CLI will authenticate as an
+  // app for a particular space instead of authenticating as an account. This
+  // is especially useful in CI, which must be independent of a team member.
+  const appToken = process.env.RONIN_TOKEN;
+
   // If there is no active session, automatically start one and then continue
   // with the execution of the requested sub command, if there is one.
   const session = await getSession();
-  if (!session) await logIn();
+  if (!session) await logIn(appToken);
 
   // This ensures that people can accidentally type uppercase letters and still
   // get the command they are looking for.
   const normalizedPositionals = positionals.map((positional) => positional.toLowerCase());
 
   // `login` command
-  if (normalizedPositionals.includes('login')) return logIn();
+  if (normalizedPositionals.includes('login')) return logIn(appToken);
 
   // `init` command
   if (normalizedPositionals.includes('init')) return initializeProject(positionals);

--- a/src/bin/utils/session.ts
+++ b/src/bin/utils/session.ts
@@ -64,7 +64,7 @@ export const storeSession = async (token: string) => {
   return writeConfigFile(CACHE_DIR_FILE, JSON.stringify({ token }, null, 2));
 };
 
-export const storeSessionforNPM = async (token: string) => {
+export const storeTokenForNPM = async (token: string) => {
   const npmConfigFile = process.env['npm_config_userconfig'] || path.join(os.homedir(), '.npmrc');
   const npmConfigContents = await readConfigFile(npmConfigFile, 'npm', ini.parse);
 
@@ -74,7 +74,7 @@ export const storeSessionforNPM = async (token: string) => {
   await writeConfigFile(npmConfigFile, ini.stringify(npmConfigContents));
 };
 
-export const storeSessionForBun = async (token: string) => {
+export const storeTokenForBun = async (token: string) => {
   const bunConfigFile = path.join(os.homedir(), '.bunfig.toml');
   const bunConfigContents = await readConfigFile(bunConfigFile, 'Bun', toml.parse);
 


### PR DESCRIPTION
This change ensures that all commands of the RONIN CLI are able to function without an account session if a `RONIN_TOKEN` environment variable containing a RONIN app token is provided instead.

It therefore also completes RON-927.