### PR TITLE
Print error if CLI is invoked without token

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -60,6 +60,15 @@ const run = async () => {
   // `login` sub command is invoked, we don't need to auto-login, since the
   // command itself will handle it already.
   const session = await getSession();
+
+  if (!process.stdout.isTTY && !session && !appToken) {
+    let message = 'If RONIN CLI is invoked from a non-interactive shell, ';
+    message += 'a `RONIN_TOKEN` environment variable containing an app token must be provided.';
+
+    console.error(message);
+    process.exit(1);
+  }
+
   if (!session && !normalizedPositionals.includes('login')) await logIn(appToken);
 
   // `login` sub command


### PR DESCRIPTION
This change ensures that, if RONIN CLI is run from a non-interactive shell (e.g. in CI or from a script), a `RONIN_TOKEN` environment variable containing an app token must be provided, since, otherwise `ronin login` will hang forever waiting for an account session to be approved.

But also, regardless of the technical aspect, we want people to use app tokens when invoking RONIN from CIs, because CIs need to continue working even if the people that set them up are no longer a part of the company, so they can't be based on account sessions.