### PR TITLE
Avoid recursions in data hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,8 +25,10 @@
           "accessors",
           "unicode",
           "deranks",
-          "Storable",
-          "gmail"
+          "storable",
+          "gmail",
+          "cloudflare",
+          "runtimes"
         ],
         "comments": true,
         "strings": false,

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -45,6 +45,8 @@ export type AfterHookHandler<TType extends QueryType, TSchema = unknown> = (
   result: TSchema,
 ) => void | Promise<void>;
 
+// The order of these types is important, as they determine the order in which
+// data hooks are run (the "data hook lifecycle").
 const HOOK_TYPES = ['before', 'during', 'after'] as const;
 
 type HookType = (typeof HOOK_TYPES)[number];

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
 import { runQueries } from '../queries';
 import type { CombinedInstructions, Query, QuerySchemaType, QueryType, Results } from '../types/query';
 import type { QueryHandlerOptions, RecursivePartial } from '../types/utils';
@@ -43,7 +45,9 @@ export type AfterHookHandler<TType extends QueryType, TSchema = unknown> = (
   result: TSchema,
 ) => void | Promise<void>;
 
-type HookType = 'before' | 'during' | 'after';
+const HOOK_TYPES = ['before', 'during', 'after'] as const;
+
+type HookType = (typeof HOOK_TYPES)[number];
 
 type HookKeys = (
   | { [K in QueryType]: K }
@@ -131,10 +135,23 @@ const getSchema = (
  *
  * @returns The method name constructed from the hook and query types.
  */
-const getMethodName = (hookType: HookType, queryType: string): string => {
+const getMethodName = (hookType: HookType, queryType: QueryType): string => {
   const capitalizedQueryType = queryType[0].toUpperCase() + queryType.slice(1);
   return hookType === 'during' ? queryType : hookType + capitalizedQueryType;
 };
+
+interface HookContext {
+  hookType: HookType;
+  queryType: QueryType;
+  querySchema: string;
+}
+
+/**
+ * If a query is being run explicitly by importing the client inside a data
+ * hook, this context will contain information about the hook in which the
+ * query is being run.
+ */
+const HOOK_CONTEXT = new AsyncLocalStorage<HookContext>();
 
 /**
  * Based on which type of query is being executed (e.g. "get" or "create"),
@@ -154,7 +171,7 @@ const invokeHook = async (
   hooks: Hooks,
   hookType: HookType,
   query: {
-    type: string;
+    type: QueryType;
     schema: string;
     plural: boolean;
     instruction: unknown;
@@ -194,15 +211,38 @@ const invokeHook = async (
     hookArguments[2] = queryResult;
   }
 
-  if (hooksForSchema && hookName in hooksForSchema) {
+  // In order to prevent infinite recursions inside data hooks, we want to make
+  // sure that queries that are run explicitly (by importing the client) inside
+  // a data hook don't cause those same parent hooks to run again.
+  //
+  // In other words: If a query is run inside a data hook, all data hooks of
+  // that nested query will run. If that query is for the same query type and
+  // schema as the surrounding data hook, however, we only want to run data
+  // hooks after the current (surrounding) data hook type.
+  const parentHook = HOOK_CONTEXT.getStore();
+  const shouldSkip =
+    parentHook &&
+    parentHook.queryType === query.type &&
+    parentHook.querySchema === query.schema &&
+    HOOK_TYPES.indexOf(hookType) <= HOOK_TYPES.indexOf(parentHook.hookType);
+
+  if (hooksForSchema && hookName in hooksForSchema && !shouldSkip) {
     const [instructions, isMultiple, queryResults] = hookArguments;
 
     const hook = hooksForSchema[hookName as keyof typeof hooksForSchema];
 
-    const result =
-      hookType === 'after'
-        ? await (hook as AfterHook<QueryType, unknown>)(instructions, isMultiple, queryResults)
-        : await (hook as BeforeHook<QueryType> | DuringHook<QueryType>)(instructions, isMultiple);
+    const result = HOOK_CONTEXT.run(
+      {
+        hookType,
+        queryType: query.type,
+        querySchema: query.schema,
+      },
+      async () => {
+        return hookType === 'after'
+          ? await (hook as AfterHook<QueryType, unknown>)(instructions, isMultiple, queryResults)
+          : await (hook as BeforeHook<QueryType> | DuringHook<QueryType>)(instructions, isMultiple);
+      },
+    );
 
     return { ran: true, result };
   }

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -153,21 +153,15 @@ interface HookContext {
  * hook, this context will contain information about the hook in which the
  * query is being run.
  */
-let HOOK_CONTEXT: Promise<AsyncLocalStorage<HookContext>> | undefined;
-
-// On certain edge runtimes (such as Cloudflare Workers), the `async_hooks`
-// module requires a compatibility config flag to be provided. Since the RONIN
-// TypeScript client must be usable without compatibility flags, we need to
-// wrap the code below into a try-catch block.
-//
-// We also can't use top-level `await`, as that would break the CJS bundle.
-try {
-  HOOK_CONTEXT = import('async_hooks').then(({ AsyncLocalStorage }) => {
-    return new AsyncLocalStorage<HookContext>();
+const HOOK_CONTEXT = import('async_hooks')
+  // We can't use top-level `await`, as that would break the CJS bundle.
+  .then(({ AsyncLocalStorage }) => new AsyncLocalStorage<HookContext>())
+  .catch(() => {
+    // On certain edge runtimes (such as Cloudflare Workers), the `async_hooks`
+    // module requires a compatibility config flag to be provided. Since the
+    // TypeScript client must be usable without compatibility flags, we need to
+    // catch the errors.
   });
-} catch (err) {
-  // Ignore errors
-}
 
 /**
  * Based on which type of query is being executed (e.g. "get" or "create"),

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -1,4 +1,4 @@
-import { AsyncLocalStorage } from 'async_hooks';
+import type { AsyncLocalStorage } from 'async_hooks';
 
 import { runQueries } from '../queries';
 import type { CombinedInstructions, Query, QuerySchemaType, QueryType, Results } from '../types/query';
@@ -153,7 +153,13 @@ interface HookContext {
  * hook, this context will contain information about the hook in which the
  * query is being run.
  */
-const HOOK_CONTEXT = new AsyncLocalStorage<HookContext>();
+let HOOK_CONTEXT: AsyncLocalStorage<HookContext> | undefined;
+
+try {
+  HOOK_CONTEXT = new (await import('async_hooks'))['AsyncLocalStorage']();
+} catch (err) {
+  // Ignore errors
+}
 
 /**
  * Based on which type of query is being executed (e.g. "get" or "create"),
@@ -221,7 +227,7 @@ const invokeHook = async (
   // that nested query will run. If that query is for the same query type and
   // schema as the surrounding data hook, however, we only want to run data
   // hooks after the current (surrounding) data hook type.
-  const parentHook = HOOK_CONTEXT.getStore();
+  const parentHook = HOOK_CONTEXT?.getStore();
   const shouldSkip =
     parentHook &&
     parentHook.queryType === query.type &&
@@ -233,7 +239,7 @@ const invokeHook = async (
 
     const hook = hooksForSchema[hookName as keyof typeof hooksForSchema];
 
-    const result = await HOOK_CONTEXT.run(
+    const result = await HOOK_CONTEXT?.run(
       {
         hookType,
         queryType: query.type,

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -155,6 +155,10 @@ interface HookContext {
  */
 let HOOK_CONTEXT: AsyncLocalStorage<HookContext> | undefined;
 
+// On certain edge runtimes (such as Cloudflare Workers), the `async_hooks`
+// module requires a compatibility config flag to be provided. Since the RONIN
+// TypeScript client must be usable without compatibility flags, we need to
+// wrap the code below into a try-catch block.
 try {
   HOOK_CONTEXT = new (await import('async_hooks'))['AsyncLocalStorage']();
 } catch (err) {

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -231,7 +231,7 @@ const invokeHook = async (
 
     const hook = hooksForSchema[hookName as keyof typeof hooksForSchema];
 
-    const result = HOOK_CONTEXT.run(
+    const result = await HOOK_CONTEXT.run(
       {
         hookType,
         queryType: query.type,

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -155,13 +155,7 @@ interface HookContext {
  */
 const HOOK_CONTEXT = import('async_hooks')
   // We can't use top-level `await`, as that would break the CJS bundle.
-  .then(({ AsyncLocalStorage }) => new AsyncLocalStorage<HookContext>())
-  .catch(() => {
-    // On certain edge runtimes (such as Cloudflare Workers), the `async_hooks`
-    // module requires a compatibility config flag to be provided. Since the
-    // TypeScript client must be usable without compatibility flags, we need to
-    // catch the errors.
-  });
+  .then(({ AsyncLocalStorage }) => new AsyncLocalStorage<HookContext>());
 
 /**
  * Based on which type of query is being executed (e.g. "get" or "create"),
@@ -221,7 +215,16 @@ const invokeHook = async (
     hookArguments[2] = queryResult;
   }
 
-  const parentContext = HOOK_CONTEXT ? await HOOK_CONTEXT : null;
+  let parentContext: AsyncLocalStorage<HookContext> | undefined;
+
+  try {
+    parentContext = HOOK_CONTEXT ? await HOOK_CONTEXT : undefined;
+  } catch (err) {
+    // On certain edge runtimes (such as Cloudflare Workers), the `async_hooks`
+    // module requires a compatibility config flag to be provided. Since the
+    // TypeScript client must be usable without compatibility flags, we need to
+    // catch the errors and ignore them.
+  }
 
   // In order to prevent infinite recursions inside data hooks, we want to make
   // sure that queries that are run explicitly (by importing the client) inside

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -153,14 +153,18 @@ interface HookContext {
  * hook, this context will contain information about the hook in which the
  * query is being run.
  */
-let HOOK_CONTEXT: AsyncLocalStorage<HookContext> | undefined;
+let HOOK_CONTEXT: Promise<AsyncLocalStorage<HookContext>> | undefined;
 
 // On certain edge runtimes (such as Cloudflare Workers), the `async_hooks`
 // module requires a compatibility config flag to be provided. Since the RONIN
 // TypeScript client must be usable without compatibility flags, we need to
 // wrap the code below into a try-catch block.
+//
+// We also can't use top-level `await`, as that would break the CJS bundle.
 try {
-  HOOK_CONTEXT = new (await import('async_hooks'))['AsyncLocalStorage']();
+  HOOK_CONTEXT = import('async_hooks').then(({ AsyncLocalStorage }) => {
+    return new AsyncLocalStorage<HookContext>();
+  });
 } catch (err) {
   // Ignore errors
 }
@@ -223,6 +227,8 @@ const invokeHook = async (
     hookArguments[2] = queryResult;
   }
 
+  const parentContext = HOOK_CONTEXT ? await HOOK_CONTEXT : null;
+
   // In order to prevent infinite recursions inside data hooks, we want to make
   // sure that queries that are run explicitly (by importing the client) inside
   // a data hook don't cause those same parent hooks to run again.
@@ -231,7 +237,7 @@ const invokeHook = async (
   // that nested query will run. If that query is for the same query type and
   // schema as the surrounding data hook, however, we only want to run data
   // hooks after the current (surrounding) data hook type.
-  const parentHook = HOOK_CONTEXT?.getStore();
+  const parentHook = parentContext?.getStore();
   const shouldSkip =
     parentHook &&
     parentHook.queryType === query.type &&
@@ -243,18 +249,22 @@ const invokeHook = async (
 
     const hook = hooksForSchema[hookName as keyof typeof hooksForSchema];
 
-    const result = await HOOK_CONTEXT?.run(
-      {
-        hookType,
-        queryType: query.type,
-        querySchema: query.schema,
-      },
-      async () => {
-        return hookType === 'after'
-          ? await (hook as AfterHook<QueryType, unknown>)(instructions, isMultiple, queryResults)
-          : await (hook as BeforeHook<QueryType> | DuringHook<QueryType>)(instructions, isMultiple);
-      },
-    );
+    const caller = async () => {
+      return hookType === 'after'
+        ? await (hook as AfterHook<QueryType, unknown>)(instructions, isMultiple, queryResults)
+        : await (hook as BeforeHook<QueryType> | DuringHook<QueryType>)(instructions, isMultiple);
+    };
+
+    const result = parentContext
+      ? await parentContext.run(
+          {
+            hookType,
+            queryType: query.type,
+            querySchema: query.schema,
+          },
+          caller,
+        )
+      : await caller();
 
     return { ran: true, result };
   }

--- a/tests/integration/edge.test.ts
+++ b/tests/integration/edge.test.ts
@@ -1,5 +1,6 @@
-import { plugin } from 'bun';
 import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import createSyntaxFactory from 'src';
+import { runQueriesWithHooks } from 'src/utils/data-hooks';
 
 const mockFetch = mock(async () => {
   return Response.json({
@@ -14,65 +15,12 @@ describe('edge runtime', () => {
     mockFetch.mockClear();
   });
 
-  test('invoke `ronin` from an edge runtime that does not support `async_hooks`', async () => {
-    const queries = [
-      {
-        create: { account: { with: { handle: 'leo' } } },
-      },
-    ];
-
-    const hookInvocation = { happened: () => true };
-    const hookInvocationHappened = spyOn(hookInvocation, 'happened');
-
-    const promisesToAwait: Promise<unknown>[] = [];
-
-    process.env.ASYNC_HOOKS_PATH = 'async_hooks_mock';
-
-    plugin({
-      name: 'async_hooks',
-      setup(build) {
-        build.module('async_hooks_mock', () => {
-          console.log('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
-          throw new Error('async_hooks is not supported');
-        });
-      },
-    });
-
-    const { runQueriesWithHooks } = await import('src/utils/data-hooks');
-
-    await runQueriesWithHooks(queries, {
-      token: '1234',
-      hooks: {
-        account: {
-          afterCreate: async function () {
-            // Sleep for 50 milliseconds to simulate an asynchronous action.
-            await Bun.sleep(50);
-
-            hookInvocation.happened();
-          },
-        },
-      },
-      waitUntil: (promise) => {
-        promisesToAwait.push(promise);
-      },
-    });
-
-    expect(promisesToAwait.length).toBeGreaterThan(0);
-
-    // Wait for asynchronous actions to finish.
-    expect(hookInvocationHappened).not.toHaveBeenCalled();
-    await Promise.all(promisesToAwait);
-    expect(hookInvocationHappened).toHaveBeenCalled();
-  });
-
   test('invoke `ronin` from an edge runtime without passing a token', async () => {
     let error: Error | undefined;
 
     // Simulate a web runtime.
     const oldProcess = global.process;
     global.process = undefined as unknown as NodeJS.Process;
-
-    const { default: createSyntaxFactory } = await import('src/index');
 
     try {
       const factory = createSyntaxFactory({});
@@ -96,8 +44,6 @@ describe('edge runtime', () => {
     // Simulate a web runtime.
     const oldProcess = global.process;
     global.process = undefined as unknown as NodeJS.Process;
-
-    const { default: createSyntaxFactory } = await import('src/index');
 
     try {
       const factory = createSyntaxFactory({
@@ -137,14 +83,12 @@ describe('edge runtime', () => {
     const oldProcess = global.process;
     global.process = undefined as unknown as NodeJS.Process;
 
-    const { runQueriesWithHooks } = await import('src/utils/data-hooks');
-
     await runQueriesWithHooks(queries, {
       hooks: {
         account: {
           afterCreate: async function () {
             // Sleep for 50 milliseconds to simulate an asynchronous action.
-            await Bun.sleep(50);
+            await new Promise((resolve) => setTimeout(resolve, 50));
 
             hookInvocation.happened();
           },

--- a/tests/integration/edge.test.ts
+++ b/tests/integration/edge.test.ts
@@ -1,6 +1,5 @@
+import { plugin } from 'bun';
 import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
-import createSyntaxFactory from 'src';
-import { runQueriesWithHooks } from 'src/utils/data-hooks';
 
 const mockFetch = mock(async () => {
   return Response.json({
@@ -15,12 +14,65 @@ describe('edge runtime', () => {
     mockFetch.mockClear();
   });
 
+  test('invoke `ronin` from an edge runtime that does not support `async_hooks`', async () => {
+    const queries = [
+      {
+        create: { account: { with: { handle: 'leo' } } },
+      },
+    ];
+
+    const hookInvocation = { happened: () => true };
+    const hookInvocationHappened = spyOn(hookInvocation, 'happened');
+
+    const promisesToAwait: Promise<unknown>[] = [];
+
+    process.env.ASYNC_HOOKS_PATH = 'async_hooks_mock';
+
+    plugin({
+      name: 'async_hooks',
+      setup(build) {
+        build.module('async_hooks_mock', () => {
+          console.log('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+          throw new Error('async_hooks is not supported');
+        });
+      },
+    });
+
+    const { runQueriesWithHooks } = await import('src/utils/data-hooks');
+
+    await runQueriesWithHooks(queries, {
+      token: '1234',
+      hooks: {
+        account: {
+          afterCreate: async function () {
+            // Sleep for 50 milliseconds to simulate an asynchronous action.
+            await Bun.sleep(50);
+
+            hookInvocation.happened();
+          },
+        },
+      },
+      waitUntil: (promise) => {
+        promisesToAwait.push(promise);
+      },
+    });
+
+    expect(promisesToAwait.length).toBeGreaterThan(0);
+
+    // Wait for asynchronous actions to finish.
+    expect(hookInvocationHappened).not.toHaveBeenCalled();
+    await Promise.all(promisesToAwait);
+    expect(hookInvocationHappened).toHaveBeenCalled();
+  });
+
   test('invoke `ronin` from an edge runtime without passing a token', async () => {
     let error: Error | undefined;
 
     // Simulate a web runtime.
     const oldProcess = global.process;
     global.process = undefined as unknown as NodeJS.Process;
+
+    const { default: createSyntaxFactory } = await import('src/index');
 
     try {
       const factory = createSyntaxFactory({});
@@ -44,6 +96,8 @@ describe('edge runtime', () => {
     // Simulate a web runtime.
     const oldProcess = global.process;
     global.process = undefined as unknown as NodeJS.Process;
+
+    const { default: createSyntaxFactory } = await import('src/index');
 
     try {
       const factory = createSyntaxFactory({
@@ -82,6 +136,8 @@ describe('edge runtime', () => {
     // Simulate a web runtime.
     const oldProcess = global.process;
     global.process = undefined as unknown as NodeJS.Process;
+
+    const { runQueriesWithHooks } = await import('src/utils/data-hooks');
 
     await runQueriesWithHooks(queries, {
       hooks: {

--- a/tests/integration/edge.test.ts
+++ b/tests/integration/edge.test.ts
@@ -88,7 +88,7 @@ describe('edge runtime', () => {
         account: {
           afterCreate: async function () {
             // Sleep for 50 milliseconds to simulate an asynchronous action.
-            await new Promise((resolve) => setTimeout(resolve, 50));
+            await Bun.sleep(50);
 
             hookInvocation.happened();
           },

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -302,4 +302,51 @@ describe('hooks', () => {
     });
     expect(finalMultiple).toBe(false);
   });
+
+  test('run a query inside a data hook and avoid recursion', async () => {
+    let hookInvoked = false;
+
+    const { create } = createSyntaxFactory({
+      fetch: async (request) => {
+        return Response.json({
+          results: [
+            {
+              record: {
+                id: '1234',
+                firstName: 'Juri',
+                handle: 'juri',
+              },
+            },
+          ],
+        });
+      },
+      hooks: {
+        account: {
+          async create() {
+            // If an infinite recursion is detected, we need to exit
+            // immediately instead of performing a test assertion, because the
+            // code will otherwise run forever (until memory is exceeded).
+            if (hookInvoked) {
+              console.error('Infinite recursion detected in test. Exiting.');
+              process.exit(1);
+            }
+
+            hookInvoked = true;
+
+            await create.account.with({
+              handle: 'not-juri',
+            });
+
+            return { handle: 'juri' };
+          },
+        },
+      },
+    });
+
+    const result = await create.account.with({
+      handle: 'juri',
+    });
+
+    expect(result).toMatchObject({ handle: 'juri' });
+  });
 });

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -307,7 +307,7 @@ describe('hooks', () => {
     let hookInvoked = false;
 
     const { create } = createSyntaxFactory({
-      fetch: async (request) => {
+      fetch: async () => {
         return Response.json({
           results: [
             {


### PR DESCRIPTION
This change ensures that, if a query is run inside a data hook and that query uses the same query type and schema as the data hook itself, a recursion is avoided.

As a result, this gets us closer to completing RON-885.