### PR TITLE
Make it possible to provide function for composing data hooks

### DIFF
--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -6,7 +6,8 @@ export interface QueryHandlerOptions {
    *
    * Alternatively, a function that returns the object may be provided instead,
    * which is useful for cases in which the list of hooks might be generated
-   * dynamically or augmented with additional arguments.
+   * dynamically or augmented with additional arguments that are only available
+   * at the time when the queries are executed.
    */
   hooks?: Hooks | (() => Hooks);
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -3,8 +3,12 @@ import type { Hooks } from '../utils/data-hooks';
 export interface QueryHandlerOptions {
   /**
    * Object containing data hooks for defined schemas.
+   *
+   * Alternatively, a function that returns the object may be provided instead,
+   * which is useful for cases in which the list of hooks might be generated
+   * dynamically or augmented with additional arguments.
    */
-  hooks?: Hooks;
+  hooks?: Hooks | (() => Hooks);
 
   /**
    * Token used to authenticate against RONIN. By default,

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -1,4 +1,4 @@
-import type asyncHooks from 'async_hooks';
+import type AsyncHooks from 'async_hooks';
 
 import { runQueries } from '../queries';
 import type { CombinedInstructions, Query, QuerySchemaType, QueryType, Results } from '../types/query';
@@ -157,7 +157,7 @@ const HOOK_CONTEXT =
   // We don't want bundlers to error if `async_hooks` is not available, so we
   // obfuscase the module name to prevent static analysis.
   // We can't use top-level `await`, as that would break the CJS bundle.
-  (import('async' + '_' + 'hooks') as Promise<typeof asyncHooks>).then(({ AsyncLocalStorage }) => {
+  (import('async' + '_' + 'hooks') as Promise<typeof AsyncHooks>).then(({ AsyncLocalStorage }) => {
     return new AsyncLocalStorage<HookContext>();
   });
 
@@ -219,7 +219,7 @@ const invokeHook = async (
     hookArguments[2] = queryResult;
   }
 
-  let parentContext: AsyncLocalStorage<HookContext> | undefined;
+  let parentContext: AsyncHooks.AsyncLocalStorage<HookContext> | undefined;
 
   try {
     parentContext = HOOK_CONTEXT ? await HOOK_CONTEXT : undefined;

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -377,11 +377,14 @@ export const runQueriesWithHooks = async <T>(
   let modifiableQueries = Array.from(queries);
   const modifiableResults = new Array<T>();
 
-  const { hooks, waitUntil } = options;
+  const { hooks: defaultHooks, waitUntil } = options;
 
   // If no hooks were provided, we can just run the queries and return
   // the results.
-  if (!hooks) return runQueries<T>(modifiableQueries, options);
+  if (!defaultHooks) return runQueries<T>(modifiableQueries, options);
+
+  // If a function for generating the list of hooks was provided, call it.
+  const hooks = typeof defaultHooks === 'function' ? defaultHooks() : defaultHooks;
 
   // We're intentionally considering the entire `hooks` option here, instead of
   // searching for "after" hooks inside of it, because the latter would increase

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -155,7 +155,7 @@ interface HookContext {
  */
 const HOOK_CONTEXT =
   // We don't want bundlers to error if `async_hooks` is not available, so we
-  // obfuscase the module name to prevent static analysis.
+  // obfuscate the module name to prevent static analysis.
   // We can't use top-level `await`, as that would break the CJS bundle.
   (import('async' + '_' + 'hooks') as Promise<typeof AsyncHooks>).then(({ AsyncLocalStorage }) => {
     return new AsyncLocalStorage<HookContext>();

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -1,4 +1,4 @@
-import type { AsyncLocalStorage } from 'async_hooks';
+import type asyncHooks from 'async_hooks';
 
 import { runQueries } from '../queries';
 import type { CombinedInstructions, Query, QuerySchemaType, QueryType, Results } from '../types/query';
@@ -153,9 +153,13 @@ interface HookContext {
  * hook, this context will contain information about the hook in which the
  * query is being run.
  */
-const HOOK_CONTEXT = import('async_hooks')
+const HOOK_CONTEXT =
+  // We don't want bundlers to error if `async_hooks` is not available, so we
+  // obfuscase the module name to prevent static analysis.
   // We can't use top-level `await`, as that would break the CJS bundle.
-  .then(({ AsyncLocalStorage }) => new AsyncLocalStorage<HookContext>());
+  (import('async' + '_' + 'hooks') as Promise<typeof asyncHooks>).then(({ AsyncLocalStorage }) => {
+    return new AsyncLocalStorage<HookContext>();
+  });
 
 /**
  * Based on which type of query is being executed (e.g. "get" or "create"),


### PR DESCRIPTION
This change makes it possible to provide a function as the `hooks` config option for the TypeScript client, which allows for dynamically generating a list of hooks on-demand, which may optionally be done using async context as well.

We don't allow this function to be `async` on purpose, as that would **slow down** the query execution. Instead, the function should be used to **speed up** the data hooks. For example, if someone would like to define [async context](https://nodejs.org/api/async_context.html#class-asynclocalstorage) that depends on parent hooks (which is a use case that we have ourselves), they can use this function to only initialize the context once per level of data hooks, instead of once per data hook.