### PR TITLE
Prefix import for async hooks

### DIFF
--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -148,16 +148,18 @@ interface HookContext {
   querySchema: string;
 }
 
+// We don't want bundlers to error if `async_hooks` is not available, so we
+// obfuscate the module name to prevent static analysis.
+const asyncHooksImport = 'node:async_hooks';
+
 /**
  * If a query is being run explicitly by importing the client inside a data
  * hook, this context will contain information about the hook in which the
  * query is being run.
  */
 const HOOK_CONTEXT =
-  // We don't want bundlers to error if `async_hooks` is not available, so we
-  // obfuscate the module name to prevent static analysis.
   // We can't use top-level `await`, as that would break the CJS bundle.
-  (import('async' + '_' + 'hooks') as Promise<typeof AsyncHooks>).then(({ AsyncLocalStorage }) => {
+  (import(asyncHooksImport) as Promise<typeof AsyncHooks>).then(({ AsyncLocalStorage }) => {
     return new AsyncLocalStorage<HookContext>();
   });
 

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -149,7 +149,7 @@ interface HookContext {
 }
 
 // We don't want bundlers to error if `async_hooks` is not available, so we
-// obfuscate the module name to prevent static analysis.
+// prevent basic static analysis by using a dynamic variable import.
 const asyncHooksImport = 'node:async_hooks';
 
 /**


### PR DESCRIPTION
This prefixes the `async_hooks` import with `node:`, which makes it work on Cloudflare (if the Node.js compatibility flag is enabled in the config).