### PR TITLE
Accept function as factory config

### DIFF
--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -8,6 +8,10 @@ import { batch, getSyntaxProxy } from './utils';
  *
  * @param options - An optional object of options for the query execution.
  *
+ * Alternatively, a function that returns the object may be provided instead,
+ * which is useful for cases in which the config must be generated dynamically
+ * whenever a query is executed.
+ *
  * @returns An object with methods for generating and executing different types
  * of queries.
  *
@@ -42,12 +46,16 @@ import { batch, getSyntaxProxy } from './utils';
  * ]);
  * ```
  */
-export const createSyntaxFactory = (options: QueryHandlerOptions) => ({
-  create: getSyntaxProxy('create', (query) => queryHandler(query, options)) as RONIN.Creator,
-  get: getSyntaxProxy('get', (query) => queryHandler(query, options)) as RONIN.Getter,
-  set: getSyntaxProxy('set', (query) => queryHandler(query, options)) as RONIN.Setter,
-  drop: getSyntaxProxy('drop', (query) => queryHandler(query, options)) as RONIN.Dropper,
-  count: getSyntaxProxy('count', (query) => queryHandler(query, options)) as RONIN.Counter,
-  batch: <T extends [Promise<any>, ...Promise<any>[]]>(operations: () => T) =>
-    batch<T>(operations, (queries) => queriesHandler(queries, options)),
-});
+export const createSyntaxFactory = (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
+  const normalizedOptions = typeof options === 'function' ? options() : options;
+
+  return {
+    create: getSyntaxProxy('create', (query) => queryHandler(query, normalizedOptions)) as RONIN.Creator,
+    get: getSyntaxProxy('get', (query) => queryHandler(query, normalizedOptions)) as RONIN.Getter,
+    set: getSyntaxProxy('set', (query) => queryHandler(query, normalizedOptions)) as RONIN.Setter,
+    drop: getSyntaxProxy('drop', (query) => queryHandler(query, normalizedOptions)) as RONIN.Dropper,
+    count: getSyntaxProxy('count', (query) => queryHandler(query, normalizedOptions)) as RONIN.Counter,
+    batch: <T extends [Promise<any>, ...Promise<any>[]]>(operations: () => T) =>
+      batch<T>(operations, (queries) => queriesHandler(queries, normalizedOptions)),
+  };
+};

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -3,13 +3,8 @@ import type { Hooks } from '../utils/data-hooks';
 export interface QueryHandlerOptions {
   /**
    * Object containing data hooks for defined schemas.
-   *
-   * Alternatively, a function that returns the object may be provided instead,
-   * which is useful for cases in which the list of hooks might be generated
-   * dynamically or augmented with additional arguments that are only available
-   * at the time when the queries are executed.
    */
-  hooks?: Hooks | (() => Hooks);
+  hooks?: Hooks;
 
   /**
    * Token used to authenticate against RONIN. By default,

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -371,14 +371,11 @@ export const runQueriesWithHooks = async <T>(
   let modifiableQueries = Array.from(queries);
   const modifiableResults = new Array<T>();
 
-  const { hooks: defaultHooks, waitUntil } = options;
+  const { hooks, waitUntil } = options;
 
   // If no hooks were provided, we can just run the queries and return
   // the results.
-  if (!defaultHooks) return runQueries<T>(modifiableQueries, options);
-
-  // If a function for generating the list of hooks was provided, call it.
-  const hooks = typeof defaultHooks === 'function' ? defaultHooks() : defaultHooks;
+  if (!hooks) return runQueries<T>(modifiableQueries, options);
 
   // We're intentionally considering the entire `hooks` option here, instead of
   // searching for "after" hooks inside of it, because the latter would increase

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -90,9 +90,9 @@ describe('hooks', () => {
     );
   });
 
-  test('run `get` query through factory with dynamically generated data hooks', async () => {
-    const { get } = createSyntaxFactory({
-      hooks: () => ({
+  test('run `get` query through factory with dynamically generated config', async () => {
+    const { get } = createSyntaxFactory(() => ({
+      hooks: {
         account: {
           beforeGet(query, multiple) {
             if (multiple) {
@@ -110,8 +110,8 @@ describe('hooks', () => {
             return query;
           },
         },
-      }),
-    });
+      },
+    }));
 
     // @ts-expect-error `handle` is undefined due not not having the schema types.
     await get.account.with.handle('juri');


### PR DESCRIPTION
This simplifies the change landed in https://github.com/ronin-co/client/pull/44 and makes it possible to define the entire factory config of the TypeScript client as a function, instead of just the `hooks` option.

An explanation of why this is useful can be found in the attached code comment.