### PR TITLE
Run option factory when queries are run

### DIFF
--- a/src/syntax/handlers.ts
+++ b/src/syntax/handlers.ts
@@ -1,6 +1,6 @@
 import { runQueriesWithStorageAndHooks } from 'src/queries';
 import type { Query } from 'src/types/query';
-import type { QueryHandlerOptions } from 'src/types/utils';
+import type { QueryHandlerOptionsFactory } from 'src/types/utils';
 
 /**
  * Executes an array of queries and handles their results. It is used to execute
@@ -22,7 +22,9 @@ import type { QueryHandlerOptions } from 'src/types/utils';
  * The `RONIN_TOKEN` environment variable will be used (if available) to
  * authenticate requests if the `token` option is not provided.
  */
-export const queriesHandler = async (queries: Query[], options: QueryHandlerOptions = {}) => {
+export const queriesHandler = async (queries: Query[], optionsFactory: QueryHandlerOptionsFactory = {}) => {
+  const options = typeof optionsFactory === 'function' ? optionsFactory() : optionsFactory;
+
   if (!options.token && typeof process !== 'undefined') {
     const token =
       typeof process?.env !== 'undefined'
@@ -70,7 +72,7 @@ export const queriesHandler = async (queries: Query[], options: QueryHandlerOpti
  * );
  * ```
  */
-export const queryHandler = async (query: Query, options: QueryHandlerOptions) => {
+export const queryHandler = async (query: Query, options: QueryHandlerOptionsFactory) => {
   const results = await queriesHandler([query], options);
   return results[0];
 };

--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -1,5 +1,5 @@
 import type { RONIN } from '../types/codegen';
-import type { QueryHandlerOptions } from '../types/utils';
+import type { QueryHandlerOptionsFactory } from '../types/utils';
 import { queriesHandler, queryHandler } from './handlers';
 import { batch, getSyntaxProxy } from './utils';
 
@@ -46,16 +46,12 @@ import { batch, getSyntaxProxy } from './utils';
  * ]);
  * ```
  */
-export const createSyntaxFactory = (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
-  const normalizedOptions = typeof options === 'function' ? options() : options;
-
-  return {
-    create: getSyntaxProxy('create', (query) => queryHandler(query, normalizedOptions)) as RONIN.Creator,
-    get: getSyntaxProxy('get', (query) => queryHandler(query, normalizedOptions)) as RONIN.Getter,
-    set: getSyntaxProxy('set', (query) => queryHandler(query, normalizedOptions)) as RONIN.Setter,
-    drop: getSyntaxProxy('drop', (query) => queryHandler(query, normalizedOptions)) as RONIN.Dropper,
-    count: getSyntaxProxy('count', (query) => queryHandler(query, normalizedOptions)) as RONIN.Counter,
-    batch: <T extends [Promise<any>, ...Promise<any>[]]>(operations: () => T) =>
-      batch<T>(operations, (queries) => queriesHandler(queries, normalizedOptions)),
-  };
-};
+export const createSyntaxFactory = (options: QueryHandlerOptionsFactory) => ({
+  create: getSyntaxProxy('create', (query) => queryHandler(query, options)) as RONIN.Creator,
+  get: getSyntaxProxy('get', (query) => queryHandler(query, options)) as RONIN.Getter,
+  set: getSyntaxProxy('set', (query) => queryHandler(query, options)) as RONIN.Setter,
+  drop: getSyntaxProxy('drop', (query) => queryHandler(query, options)) as RONIN.Dropper,
+  count: getSyntaxProxy('count', (query) => queryHandler(query, options)) as RONIN.Counter,
+  batch: <T extends [Promise<any>, ...Promise<any>[]]>(operations: () => T) =>
+    batch<T>(operations, (queries) => queriesHandler(queries, options)),
+});

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -27,6 +27,8 @@ export interface QueryHandlerOptions {
   waitUntil?: (promise: Promise<unknown>) => void;
 }
 
+export type QueryHandlerOptionsFactory = QueryHandlerOptions | (() => QueryHandlerOptions);
+
 /**
  * Utility type to make all properties of an object optional.
  */


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/client/pull/48!

If a function is provided as config for the TypeScript client factory, the function should only be invoked once a query is actually executed, otherwise its purpose is defeated (see the code comment on the previous PR).