### PR TITLE
Fixed `process is not defined` error

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -177,7 +177,7 @@ export const runQueries = async <T>(
   const endFormatting = performance.now();
 
   const VERBOSE_LOGGING =
-    (typeof process?.env !== 'undefined' && process.env.__RENDER_DEBUG_LEVEL === 'verbose') ||
+    (typeof process !== 'undefined' && process?.env && process.env.__RENDER_DEBUG_LEVEL === 'verbose') ||
     (typeof import.meta?.env !== 'undefined' && import.meta.env.__RENDER_DEBUG_LEVEL === 'verbose');
 
   if (VERBOSE_LOGGING) {


### PR DESCRIPTION
This change will fix a `process is not defined` error that could occur in some edge runtimes, like Cloudflare Workers, by ensuring that `process` is actually available before trying to access any of its nested properties.