### PR TITLE
Moved utils to dedicated `utils` export

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
       "import": "./dist/types/index.js",
       "require": "./dist/types/index.cjs",
       "types": "./dist/types/index.d.ts"
+    },
+    "./utils": {
+      "import": "./dist/utils/index.js",
+      "require": "./dist/utils/index.cjs",
+      "types": "./dist/utils/index.d.ts"
     }
   },
   "typesVersions": {
@@ -56,6 +61,9 @@
       ],
       "types": [
         "dist/types/index.d.ts"
+      ],
+      "utils": [
+        "dist/utils/index.d.ts"
       ]
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,7 @@
-import { runQueriesWithStorageAndHooks as runQueries } from './queries';
-import { processStorableObjects } from './storage';
 import { createSyntaxFactory } from './syntax';
 
 const { create, get, set, drop, count, batch } = createSyntaxFactory({});
 
-export { create, get, set, drop, count, batch, runQueries, processStorableObjects };
+export { create, get, set, drop, count, batch };
 export type { RONIN } from './types/codegen';
 export default createSyntaxFactory;

--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -1,7 +1,7 @@
 import type { RONIN } from '../types/codegen';
 import type { QueryHandlerOptionsFactory } from '../types/utils';
 import { queriesHandler, queryHandler } from './handlers';
-import { batch, getSyntaxProxy } from './utils';
+import { getBatchProxy, getSyntaxProxy } from './utils';
 
 /**
  * Creates a syntax factory for generating and executing queries.
@@ -53,5 +53,5 @@ export const createSyntaxFactory = (options: QueryHandlerOptionsFactory) => ({
   drop: getSyntaxProxy('drop', (query) => queryHandler(query, options)) as RONIN.Dropper,
   count: getSyntaxProxy('count', (query) => queryHandler(query, options)) as RONIN.Counter,
   batch: <T extends [Promise<any>, ...Promise<any>[]]>(operations: () => T) =>
-    batch<T>(operations, (queries) => queriesHandler(queries, options)),
+    getBatchProxy<T>(operations, (queries) => queriesHandler(queries, options)),
 });

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -88,7 +88,7 @@ export const getSyntaxProxy = (queryType: string, queryHandler: (query: Query) =
  * });
  * ```
  */
-export const batch = async <T extends [Promise<any>, ...Promise<any>[]]>(
+export const getBatchProxy = async <T extends [Promise<any>, ...Promise<any>[]]>(
   operations: () => T,
   queriesHandler: (queries: Query[]) => Promise<any>,
 ): Promise<PromiseTuple<T>> => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,5 @@
+import { runQueriesWithStorageAndHooks as runQueries } from '../queries';
+import { processStorableObjects } from '../storage';
+import { getSyntaxProxy } from '../syntax/utils';
+
+export { runQueries, processStorableObjects, getSyntaxProxy };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { runQueriesWithStorageAndHooks as runQueries } from '../queries';
 import { processStorableObjects } from '../storage';
-import { getSyntaxProxy } from '../syntax/utils';
+import { getBatchProxy, getSyntaxProxy } from '../syntax/utils';
 
-export { runQueries, processStorableObjects, getSyntaxProxy };
+export { runQueries, processStorableObjects, getSyntaxProxy, getBatchProxy };


### PR DESCRIPTION
This change adds a new `ronin/utils` export containing utility functions that can be used to extend RONIN.

Most people should not use any of these functions, and we will likely make it clear that they are not part of the programmatic interface we consider to be stable (the exports in `ronin`).