### PR TITLE
Ensure working import paths

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,6 +1,6 @@
-import { printHelp, printVersion } from 'src/bin/utils/info';
 import { parseArgs } from 'util';
 
+import { printHelp, printVersion } from '../bin/utils/info';
 import initializeProject from './commands/init';
 import logIn from './commands/login';
 import { getSession } from './utils/session';

--- a/src/syntax/handlers.ts
+++ b/src/syntax/handlers.ts
@@ -1,6 +1,6 @@
-import { runQueriesWithStorageAndHooks } from 'src/queries';
-import type { Query } from 'src/types/query';
-import type { QueryHandlerOptionsFactory } from 'src/types/utils';
+import { runQueriesWithStorageAndHooks } from '../queries';
+import type { Query } from '../types/query';
+import type { QueryHandlerOptionsFactory } from '../types/utils';
 
 /**
  * Executes an array of queries and handles their results. It is used to execute

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -1,6 +1,6 @@
-import type { Query } from 'src/types/query';
-import type { PromiseTuple } from 'src/types/utils';
-import { objectFromAccessor } from 'src/utils/helpers';
+import type { Query } from '../types/query';
+import type { PromiseTuple } from '../types/utils';
+import { objectFromAccessor } from '../utils/helpers';
 
 let inBatch = false;
 

--- a/tests/integration/edge.test.ts
+++ b/tests/integration/edge.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
-import createSyntaxFactory from 'src';
-import { runQueriesWithHooks } from 'src/utils/data-hooks';
+
+import createSyntaxFactory from '../../src';
+import { runQueriesWithHooks } from '../../src/utils/data-hooks';
 
 const mockFetch = mock(async () => {
   return Response.json({

--- a/tests/integration/factory.test.ts
+++ b/tests/integration/factory.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { createSyntaxFactory } from 'src/syntax';
-import type { StoredObject } from 'src/types/storage';
+
+import { createSyntaxFactory } from '../../src/syntax';
+import type { StoredObject } from '../../src/types/storage';
 
 let mockRequestResolvedValue: Request | undefined = undefined;
 let mockResolvedRequestText: any = undefined;

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { createSyntaxFactory } from 'src/syntax';
-import type { CombinedInstructions, QueryType } from 'src/types/query';
-import { type FilteredHookQuery, runQueriesWithHooks } from 'src/utils/data-hooks';
+
+import { createSyntaxFactory } from '../../src/syntax';
+import type { CombinedInstructions, QueryType } from '../../src/types/query';
+import { type FilteredHookQuery, runQueriesWithHooks } from '../../src/utils/data-hooks';
 
 let mockResolvedRequestText: any = undefined;
 

--- a/tests/unit/error.test.ts
+++ b/tests/unit/error.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { getDotNotatedPath } from 'src/utils/errors';
+
+import { getDotNotatedPath } from '../../src/utils/errors';
 
 describe('generate dot notation', () => {
   test('generate path from segments containing only strings', () => {

--- a/tests/unit/queries.test.ts
+++ b/tests/unit/queries.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
-import { queriesHandler } from 'src/syntax/handlers';
+
+import { queriesHandler } from '../../src/syntax/handlers';
 
 let mockRequestResolvedValue: Request | undefined;
 

--- a/tests/unit/strings.test.ts
+++ b/tests/unit/strings.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test';
-import { toDashCase } from 'src/utils/helpers';
+
+import { toDashCase } from '../../src/utils/helpers';
 
 test('correctly convert strings to dash case', async () => {
   expect(toDashCase('superLongSlug')).toBe('super-long-slug');


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/client/pull/54.

Path aliases defined in `tsconfig.json` are not resolved by `tsc --build` and would require a separate build tool (a bundler) or [tsc-alias](https://www.npmjs.com/package/tsc-alias) in order to function.

I don't think it's worth running extra separate commands for the small amount of import aliases we'd need, as that might risk the reliability of the output. Not worth it right now, IMO.