### PR TITLE
Support custom factory options for `batch`

### DIFF
--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -62,6 +62,11 @@ export const createSyntaxFactory = (options: QueryHandlerOptionsFactory) => ({
   count: getSyntaxProxy('count', (query, queryOptions) =>
     queryHandler(query, queryOptions || options),
   ) as RONIN.Counter,
-  batch: <T extends [Promise<any>, ...Promise<any>[]]>(operations: () => T) =>
-    getBatchProxy<T>(operations, (queries, queryOptions) => queriesHandler(queries, queryOptions || options)),
+  batch: <T extends [Promise<any>, ...Promise<any>[]]>(
+    operations: () => T,
+    batchQueryOptions?: Record<string, unknown>,
+  ) =>
+    getBatchProxy<T>(operations, (queries, queryOptions) =>
+      queriesHandler(queries, queryOptions || batchQueryOptions || options),
+    ),
 });


### PR DESCRIPTION
This pull request adds support for custom factory options in the `batch` function. Previously, the `batch` function only accepted a callback for operations and used the default factory options. With this change, the `batch` function now accepts an additional parameter `batchQueryOptions` which allows developers to specify custom options for the batch operation. This provides more flexibility and customization when using the `batch` function.