### PR TITLE
Make `batch` extract queries synchronously

### DIFF
--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -44,7 +44,7 @@ export const getSyntaxProxy = (
           proxyTargetFunction();
 
           return new Proxy(proxyTargetFunction, {
-            async apply(_target: any, _thisArg: any, args: any[]) {
+            apply(_target: any, _thisArg: any, args: any[]) {
               const value = args[0];
               const options = args[1];
               const expanded = objectFromAccessor(path.join('.'), typeof value === 'undefined' ? {} : value);
@@ -97,7 +97,7 @@ export const getBatchProxy = async <T extends [Promise<any>, ...Promise<any>[]]>
   queriesHandler: (queries: Query[], options?: Record<string, unknown>) => Promise<any>,
 ): Promise<PromiseTuple<T>> => {
   inBatch = true;
-  const queries = (await Promise.all(operations())) as Query[];
+  const queries = operations() as Query[];
   inBatch = false;
 
   return queriesHandler(queries) as PromiseTuple<T>;

--- a/tests/integration/factory.test.ts
+++ b/tests/integration/factory.test.ts
@@ -188,6 +188,35 @@ describe('factory', () => {
     );
   });
 
+  test('make sure `batch` extracts queries synchronously', async () => {
+    const mockFetchNew = mock((request) => {
+      mockRequestResolvedValue = request;
+
+      return Response.json({
+        results: [{ ok: true }],
+      });
+    });
+
+    const factory = createSyntaxFactory({
+      fetch: async (request) => mockFetchNew(request),
+      token: 'takashitoken',
+    });
+
+    // If `batch` does not extract queries synchronously, the following
+    // `get` requests will be triggered while the `batch` is still being
+    // processed and that in turn will make the `get` requests act like they
+    // are part of
+    const res = (await Promise.all([
+      factory.batch(() => [factory.drop.accounts(), factory.drop.spaces()]),
+      factory.get.members(),
+      factory.get.users(),
+    ])) as any;
+
+    expect(res[0][0].ok).toBe(true);
+    expect(res[1].ok).toBe(true);
+    expect(res[2].ok).toBe(true);
+  });
+
   test('send correct `queries` for single `get` request using `with`', async () => {
     // @ts-expect-error `startingWith` is undefined due not not having the schema types.
     await get.accounts.with.handle.startingWith('a');

--- a/tests/integration/factory.test.ts
+++ b/tests/integration/factory.test.ts
@@ -205,7 +205,7 @@ describe('factory', () => {
     // If `batch` does not extract queries synchronously, the following
     // `get` requests will be triggered while the `batch` is still being
     // processed and that in turn will make the `get` requests act like they
-    // are part of
+    // are in a batch.
     const res = (await Promise.all([
       factory.batch(() => [factory.drop.accounts(), factory.drop.spaces()]),
       factory.get.members(),


### PR DESCRIPTION
This pull request ensures that the `batch` function extracts queries synchronously. Previously, there was a possibility of `get` requests being triggered while the `batch` was still being processed. This PR fixes that issue by making sure the `batch` function extracts queries synchronously.