### PR TITLE
Allow synchronous query handler

### DIFF
--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -29,7 +29,7 @@ let inBatch = false;
  */
 export const getSyntaxProxy = (
   queryType: string,
-  queryHandler: (query: Query, options?: Record<string, unknown>) => Promise<any>,
+  queryHandler: (query: Query, options?: Record<string, unknown>) => Promise<any> | any,
 ) => {
   return new Proxy(
     {},
@@ -94,7 +94,7 @@ export const getSyntaxProxy = (
  */
 export const getBatchProxy = async <T extends [Promise<any>, ...Promise<any>[]]>(
   operations: () => T,
-  queriesHandler: (queries: Query[], options?: Record<string, unknown>) => Promise<any>,
+  queriesHandler: (queries: Query[], options?: Record<string, unknown>) => Promise<any> | any,
 ): Promise<PromiseTuple<T>> => {
   inBatch = true;
   const queries = operations() as Query[];


### PR DESCRIPTION
When importing `getSyntaxProxy` and `getBatchProxy` from `ronin/utils`, the `queryHandler` required by both will be able to run synchronously after this change.

Most people don't need this import, but we need it for internal purposes.