### PR TITLE
Allow `getBatchProxy` to be synchronous

### DIFF
--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -1,7 +1,7 @@
 import { queriesHandler, queryHandler } from '@/src/syntax/handlers';
 import { getBatchProxy, getSyntaxProxy } from '@/src/syntax/utils';
 import type { RONIN } from '@/src/types/codegen';
-import type { QueryHandlerOptionsFactory } from '@/src/types/utils';
+import type { PromiseTuple, QueryHandlerOptionsFactory } from '@/src/types/utils';
 
 /**
  * Creates a syntax factory for generating and executing queries.
@@ -68,5 +68,5 @@ export const createSyntaxFactory = (options: QueryHandlerOptionsFactory) => ({
   ) =>
     getBatchProxy<T>(operations, (queries, queryOptions) =>
       queriesHandler(queries, queryOptions || batchQueryOptions || options),
-    ),
+    ) as Promise<PromiseTuple<T>>,
 });

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -92,13 +92,13 @@ export const getSyntaxProxy = (
  * });
  * ```
  */
-export const getBatchProxy = async <T extends [Promise<any>, ...Promise<any>[]]>(
+export const getBatchProxy = <T extends [Promise<any> | any, ...(Promise<any> | any)[]]>(
   operations: () => T,
   queriesHandler: (queries: Query[], options?: Record<string, unknown>) => Promise<any> | any,
-): Promise<PromiseTuple<T>> => {
+): Promise<PromiseTuple<T>> | T => {
   inBatch = true;
   const queries = operations() as Query[];
   inBatch = false;
 
-  return queriesHandler(queries) as PromiseTuple<T>;
+  return queriesHandler(queries) as PromiseTuple<T> | T;
 };


### PR DESCRIPTION
This change makes it possible for the internal `getBatchProxy` function under `ronin/utils` to return its results directly, instead of returning a promise that resolves to its results.