### PR TITLE
Export `PromiseTuple` from `ronin/types`

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,3 +63,6 @@ export type {
 
 // Storage
 export type { StorableObjectValue, StoredObject } from '@/src/types/storage';
+
+// Other
+export type { PromiseTuple } from '@/src/types/utils';


### PR DESCRIPTION
This contributes to closing RON-885 by exporting a helper type!