### PR TITLE
Ensure working ESM build

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,10 +10,4 @@ export default defineConfig({
   ],
   format: 'esm',
   dts: true,
-  esbuildOptions(options) {
-    // This is required in order to make `typescript` work with `esbuild`.
-    // Otherwise, you will get:
-    // Error: "Dynamic require of 'fs' is not supported".
-    options.inject = ['scripts/cjs-shim.ts'];
-  },
 });


### PR DESCRIPTION
In environments that don't contain the global variables loaded by the CJS shim, we're currently breaking the TS client.

The change right here resolves this problem temporarily.