### PR TITLE
Add minor type improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ronin",
-  "version": "4.0.18",
+  "version": "4.0.19",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -62,7 +62,7 @@ export const createSyntaxFactory = (options: QueryHandlerOptionsFactory) => ({
   count: getSyntaxProxy('count', (query, queryOptions) =>
     queryHandler(query, queryOptions || options),
   ) as RONIN.Counter,
-  batch: <T extends [Promise<any>, ...Promise<any>[]]>(
+  batch: <T extends [Promise<any>, ...Promise<any>[]] | Promise<any>[]>(
     operations: () => T,
     batchQueryOptions?: Record<string, unknown>,
   ) =>

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -92,7 +92,9 @@ export const getSyntaxProxy = (
  * });
  * ```
  */
-export const getBatchProxy = <T extends [Promise<any> | any, ...(Promise<any> | any)[]]>(
+export const getBatchProxy = <
+  T extends [Promise<any> | any, ...(Promise<any> | any)[]] | (Promise<any> | any)[],
+>(
   operations: () => T,
   queriesHandler: (queries: Query[], options?: Record<string, unknown>) => Promise<any> | any,
 ): Promise<PromiseTuple<T>> | T => {

--- a/src/types/codegen.ts
+++ b/src/types/codegen.ts
@@ -303,6 +303,10 @@ export namespace RONIN {
       options?: TOptions,
     ): Promise<ReturnBasedOnIncluding<TSchema, TIncluding> | null>;
     with: With<TSchema, Replace<TSchema, RONIN.RoninRecord, string> | null, TOptions>;
+    including: <TIncluding extends Including<TSchema> = []>(
+      values: TIncluding,
+      options?: TOptions,
+    ) => Promise<ReturnBasedOnIncluding<TSchema, TIncluding> | null>;
   }
 
   export interface IGetterPlural<
@@ -341,11 +345,12 @@ export namespace RONIN {
     TOptions = undefined,
     TModifiedReturn = Replace<TSchema, RONIN.RoninRecord, string>,
   > extends ReducedFunction {
-    (
+    <TIncluding extends Including<TSchema> = []>(
       filter: {
         with: Partial<WithObject<TSchema>>;
         to: Partial<ReplaceForSetter<TSchema>>;
         in?: TVariant;
+        including?: TIncluding;
       },
       options?: TOptions,
     ): Promise<TModifiedReturn>;
@@ -357,10 +362,11 @@ export namespace RONIN {
     TOptions = undefined,
     TModifiedReturn = Replace<TSchema, RONIN.RoninRecord, string>,
   > extends ReducedFunction {
-    (
+    <TIncluding extends Including<TSchema> = []>(
       filter?: {
         with: Partial<ReplaceForSetter<TSchema>>;
         in?: TVariant;
+        including?: TIncluding;
       },
       options?: TOptions,
     ): Promise<TModifiedReturn>;

--- a/src/types/codegen.ts
+++ b/src/types/codegen.ts
@@ -339,12 +339,8 @@ export namespace RONIN {
     before: (cursor: string, options?: TOptions) => Promise<TModifiedReturn>;
   }
 
-  export interface ISetter<
-    TSchema,
-    TVariant extends string = string,
-    TOptions = undefined,
-    TModifiedReturn = Replace<TSchema, RONIN.RoninRecord, string>,
-  > extends ReducedFunction {
+  export interface ISetter<TSchema, TVariant extends string = string, TOptions = undefined>
+    extends ReducedFunction {
     <TIncluding extends Including<TSchema> = []>(
       filter: {
         with: Partial<WithObject<TSchema>>;
@@ -353,15 +349,11 @@ export namespace RONIN {
         including?: TIncluding;
       },
       options?: TOptions,
-    ): Promise<TModifiedReturn>;
+    ): Promise<ReturnBasedOnIncluding<TSchema, TIncluding>>;
   }
 
-  export interface ICreator<
-    TSchema,
-    TVariant extends string = string,
-    TOptions = undefined,
-    TModifiedReturn = Replace<TSchema, RONIN.RoninRecord, string>,
-  > extends ReducedFunction {
+  export interface ICreator<TSchema, TVariant extends string = string, TOptions = undefined>
+    extends ReducedFunction {
     <TIncluding extends Including<TSchema> = []>(
       filter?: {
         with: Partial<ReplaceForSetter<TSchema>>;
@@ -369,8 +361,11 @@ export namespace RONIN {
         including?: TIncluding;
       },
       options?: TOptions,
-    ): Promise<TModifiedReturn>;
-    with: (values: Partial<ReplaceForSetter<TSchema>>, options?: TOptions) => Promise<TModifiedReturn>;
+    ): Promise<ReturnBasedOnIncluding<TSchema, TIncluding>>;
+    with: (
+      values: Partial<ReplaceForSetter<TSchema>>,
+      options?: TOptions,
+    ) => Promise<Replace<TSchema, RONIN.RoninRecord, string>>;
   }
 
   export interface ICounter<TSchema, TVariant extends string = string, TOptions = undefined>

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -122,7 +122,7 @@ export type Replace<TValue, TType, TReplacement> = {
 export type ReplaceForSetter<TValue> = {
   // Replace `RoninRecord` with `string`.
   [K in keyof TValue]: TValue[K] extends RONIN.RoninRecord
-    ? string | TValue[K]
+    ? string | Partial<TValue[K]>
     : // Replace `Blob` with `StorableObjectValue`.
       TValue[K] extends RONIN.Blob
       ? StorableObjectValue

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -56,7 +56,9 @@ export type RecursivePartial<T> = {
 /**
  * Utility type to convert a tuple of promises into a tuple of their resolved types.
  */
-export type PromiseTuple<T extends [Promise<any>, ...Promise<any>[]]> = { [P in keyof T]: Awaited<T[P]> };
+export type PromiseTuple<T extends [Promise<any>, ...Promise<any>[]] | Promise<any>[]> = {
+  [P in keyof T]: Awaited<T[P]>;
+};
 
 /**
  * Utility type to mark all Function.prototype methods as "deprecated" which
@@ -120,7 +122,7 @@ export type Replace<TValue, TType, TReplacement> = {
 export type ReplaceForSetter<TValue> = {
   // Replace `RoninRecord` with `string`.
   [K in keyof TValue]: TValue[K] extends RONIN.RoninRecord
-    ? string
+    ? string | TValue[K]
     : // Replace `Blob` with `StorableObjectValue`.
       TValue[K] extends RONIN.Blob
       ? StorableObjectValue


### PR DESCRIPTION
This pull request adds a few missing type improvements to the `ronin` package.

Now you can:

**Use `.including()` with singluar queries**

```typescript
await get.account.including(['session']);
```

**Assign a related record by filtering it while creating the parent record**

```typescript
await create.product.with({ 
  name: 'New product',

  // Looks for an existing category record with `slug` equal to `'electronics'`, 
  // if found, will assign that record to this field. Otherwise assigns `null`.
  category: { slug: 'electronics' }
});
```

**Pass down dynamic arrays to `batch()`**

```typescript
const counts = await batch(() => products.map(p => count.categories.with.id(p.category)));

counts // Will be typed as `number[]`

// -----

const products = await batch(() => products.map(p => create.product.with(p)));

products // Will be typed as `Product[]`

// -----

// Everything will be typed here as expected
const [categories, productsIncludingCategory, productsCount, product, ...categoriesNew] = await batch(() => [
    get.categories(),
    get.products.including(["category"]),
    count.products(),
    set.product({
        with: {  id: "asdasd" },
        to: { active: false },
        including: ["category"],
    }),

    ...localCategories.map((category) =>
        create.category.with({
            id: category.id,
            name: category.name,
        })
    ),
]);
```
