### PR TITLE
Allow for providing async context to `getBatchProxy`

### DIFF
--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -66,7 +66,7 @@ export const createSyntaxFactory = (options: QueryHandlerOptionsFactory) => ({
     operations: () => T,
     batchQueryOptions?: Record<string, unknown>,
   ) =>
-    getBatchProxy<T>(operations, (queries, queryOptions) =>
+    getBatchProxy<T>(operations, batchQueryOptions, (queries, queryOptions) =>
       queriesHandler(queries, queryOptions || batchQueryOptions || options),
     ) as Promise<PromiseTuple<T>>,
 });

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -1,8 +1,12 @@
+import type { AsyncLocalStorage } from 'node:async_hooks';
+
 import type { Query } from '@/src/types/query';
-import type { PromiseTuple } from '@/src/types/utils';
+import type { PromiseTuple, QueryHandlerOptions } from '@/src/types/utils';
 import { objectFromAccessor } from '@/src/utils/helpers';
 
 let inBatch = false;
+
+let IN_BATCH_ASYNC: AsyncLocalStorage<boolean> | undefined;
 
 /**
  * A utility function that creates a Proxy object to handle dynamic property
@@ -96,11 +100,19 @@ export const getBatchProxy = <
   T extends [Promise<any> | any, ...(Promise<any> | any)[]] | (Promise<any> | any)[],
 >(
   operations: () => T,
+  options: QueryHandlerOptions = {},
   queriesHandler: (queries: Query[], options?: Record<string, unknown>) => Promise<any> | any,
 ): Promise<PromiseTuple<T>> | T => {
-  inBatch = true;
-  const queries = operations() as Query[];
-  inBatch = false;
+  let queries: Query[] = [];
+
+  if (options.asyncContext) {
+    IN_BATCH_ASYNC = options.asyncContext;
+    IN_BATCH_ASYNC.run(true, () => operations() as Query[]);
+  } else {
+    inBatch = true;
+    queries = operations() as Query[];
+    inBatch = false;
+  }
 
   return queriesHandler(queries) as PromiseTuple<T> | T;
 };

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,7 +1,7 @@
 import type { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { StorableObjectValue } from '@/src/types/storage';
-import type { HookContext, Hooks } from '@/src/utils/data-hooks';
+import type { Hooks } from '@/src/utils/data-hooks';
 
 import type { RONIN } from './codegen';
 
@@ -37,7 +37,7 @@ export interface QueryHandlerOptions {
    * provided with the `hooks` option. If the `hooks` option is provided, this
    * option is required.
    */
-  asyncContext?: AsyncLocalStorage<HookContext>;
+  asyncContext?: AsyncLocalStorage<any>;
 }
 
 export type QueryHandlerOptionsFactory = QueryHandlerOptions | (() => QueryHandlerOptions);


### PR DESCRIPTION
In environments where `AsyncLocalStorage` is available, we must use it in order to reliably determine whether a query is being run as part of a batch of queries, or whether it is being run standalone.