### PR TITLE
Expose per-query options to `queryHandler`

### DIFF
--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -67,6 +67,9 @@ export const createSyntaxFactory = (options: QueryHandlerOptionsFactory) => ({
     batchQueryOptions?: Record<string, unknown>,
   ) =>
     getBatchProxy<T>(operations, batchQueryOptions, (queries, queryOptions) =>
-      queriesHandler(queries, queryOptions || batchQueryOptions || options),
+      queriesHandler(
+        queries.map(({ query }) => query),
+        queryOptions || batchQueryOptions || options,
+      ),
     ) as Promise<PromiseTuple<T>>,
 });

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -41,7 +41,7 @@ let IN_BATCH_SYNC = false;
  */
 export const getSyntaxProxy = (
   queryType: string,
-  queryHandler: (query: Query, options?: QueryHandlerOptions) => Promise<any> | any,
+  queryHandler: (query: Query, options?: Record<string, unknown>) => Promise<any> | any,
 ) => {
   return new Proxy(
     {},
@@ -109,7 +109,7 @@ export const getBatchProxy = <
 >(
   operations: () => T,
   options: QueryHandlerOptions = {},
-  queriesHandler: (queries: Query[], options?: QueryHandlerOptions) => Promise<any> | any,
+  queriesHandler: (queries: Query[], options?: Record<string, unknown>) => Promise<any> | any,
 ): Promise<PromiseTuple<T>> | T => {
   let queries: Query[] = [];
 

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -1,7 +1,7 @@
 import type { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { Query } from '@/src/types/query';
-import type { PromiseTuple, QueryHandlerOptions } from '@/src/types/utils';
+import type { PromiseTuple, QueryHandlerOptions, QueryItem } from '@/src/types/utils';
 import { objectFromAccessor } from '@/src/utils/helpers';
 
 /**
@@ -64,7 +64,7 @@ export const getSyntaxProxy = (
               const query = { [queryType]: expanded };
 
               if (IN_BATCH_ASYNC?.getStore() || IN_BATCH_SYNC) {
-                return query;
+                return { query, options };
               }
 
               return queryHandler(query, options);
@@ -109,9 +109,9 @@ export const getBatchProxy = <
 >(
   operations: () => T,
   options: QueryHandlerOptions = {},
-  queriesHandler: (queries: Query[], options?: Record<string, unknown>) => Promise<any> | any,
+  queriesHandler: (queries: QueryItem[], options?: Record<string, unknown>) => Promise<any> | any,
 ): Promise<PromiseTuple<T>> | T => {
-  let queries: Query[] = [];
+  let queries: QueryItem[] = [];
 
   if (options.asyncContext) {
     IN_BATCH_ASYNC = options.asyncContext;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,5 +1,6 @@
 import type { AsyncLocalStorage } from 'node:async_hooks';
 
+import type { Query } from '@/src/types/query';
 import type { StorableObjectValue } from '@/src/types/storage';
 import type { Hooks } from '@/src/utils/data-hooks';
 
@@ -128,3 +129,12 @@ export type ReplaceForSetter<TValue> = {
       ? StorableObjectValue
       : TValue[K];
 };
+
+/**
+ * Utility type that represents a particular query and any options that should
+ * be used when executing it.
+ */
+export interface QueryItem {
+  query: Query;
+  options: Record<string, unknown>;
+}

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -3,11 +3,12 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { describe, expect, test } from 'bun:test';
 
 import { get } from '@/src/index';
+import type { QueryItem } from '@/src/types/utils';
 import { getBatchProxy } from '@/src/utils';
 
 describe('syntax proxy', () => {
   test('using async context', async () => {
-    const details = await getBatchProxy(
+    const details = getBatchProxy(
       () => [get.account()],
       {
         asyncContext: new AsyncLocalStorage(),
@@ -18,5 +19,42 @@ describe('syntax proxy', () => {
     expect(details).toMatchObject({
       result: true,
     });
+  });
+
+  test('using options for query in batch', async () => {
+    const queryList: QueryItem[] = [];
+
+    getBatchProxy(
+      () => [
+        get.account(
+          {
+            with: { handle: 'juri' },
+          },
+          // @ts-expect-error This option does not exist.
+          { randomOption: true },
+        ),
+      ],
+      {
+        asyncContext: new AsyncLocalStorage(),
+      },
+      (queries) => queryList.push(...queries),
+    );
+
+    expect(queryList).toMatchObject([
+      {
+        query: {
+          get: {
+            account: {
+              with: {
+                handle: 'juri',
+              },
+            },
+          },
+        },
+        options: {
+          randomOption: true,
+        },
+      },
+    ]);
   });
 });


### PR DESCRIPTION
As you might know, it is possible to provide options when executing a query:

```typescript
await get.account(
  { with: { handle: 'juri' } },
  { token: 'x' }
);
```

The change right here ensures that, if a query inside a batch receives options, the options are exposed to the internal `queryHandler` function for further processing:

```typescript
await batch(() => [
  await get.account(
    { with: { handle: 'juri' } },
    { token: 'x' }
  );
]);
```

This doesn't change the publicly exposed programmatic API in any way, but it allows us to use these options for an internal piece of software, which relies on `getBatchProxy`.