### PR TITLE
Allow for filtering by empty fields

### DIFF
--- a/src/types/codegen.ts
+++ b/src/types/codegen.ts
@@ -32,15 +32,15 @@ export namespace RONIN {
     /**
      * Returns records where the field starts with the provided value.
      */
-    startingWith: (value: null | T | T[], options?: O) => Promise<R>;
+    startingWith: (value: T | T[], options?: O) => Promise<R>;
     /**
      * Returns records where the field ends with the provided value.
      */
-    endingWith: (value: null | T | T[], options?: O) => Promise<R>;
+    endingWith: (value: T | T[], options?: O) => Promise<R>;
     /**
      * Returns records where the field contains the provided value.
      */
-    containing: (value: null | T | T[], options?: O) => Promise<R>;
+    containing: (value: T | T[], options?: O) => Promise<R>;
   }
 
   interface NumberFilterFunction<T, R, O> extends ReducedFunction {
@@ -52,11 +52,11 @@ export namespace RONIN {
     /**
      * Returns records where the field is greater than the provided value.
      */
-    greaterThan: (value: null | T | T[], options?: O) => Promise<R>;
+    greaterThan: (value: T | T[], options?: O) => Promise<R>;
     /**
      * Returns records where the field is less than the provided value.
      */
-    lessThan: (value: null | T | T[], options?: O) => Promise<R>;
+    lessThan: (value: T | T[], options?: O) => Promise<R>;
   }
 
   interface DateFilterFunction<T, R, O> extends ReducedFunction {
@@ -68,11 +68,11 @@ export namespace RONIN {
     /**
      * Returns records where the field is greater than the provided value.
      */
-    greaterThan: (value: null | T | T[], options?: O) => Promise<R>;
+    greaterThan: (value: T | T[], options?: O) => Promise<R>;
     /**
      * Returns records where the field is less than the provided value.
      */
-    lessThan: (value: null | T | T[], options?: O) => Promise<R>;
+    lessThan: (value: T | T[], options?: O) => Promise<R>;
   }
 
   interface BooleanFilterFunction<T, R, O> extends ReducedFunction {
@@ -131,15 +131,15 @@ export namespace RONIN {
             /**
              * Matches records where the field starts with the provided value.
              */
-            startingWith?: null | string | string[];
+            startingWith?: string | string[];
             /**
              * Matches records where the field ends with the provided value.
              */
-            endingWith?: null | string | string[];
+            endingWith?: string | string[];
             /**
              * Matches records where the field contains the provided value.
              */
-            containing?: null | string | string[];
+            containing?: string | string[];
           }
     : T extends number
       ?
@@ -169,11 +169,11 @@ export namespace RONIN {
               /**
                * Matches records where the field is greater than the provided value.
                */
-              greaterThan?: null | number;
+              greaterThan?: number;
               /**
                * Matches records where the field is less than the provided value.
                */
-              lessThan?: null | number;
+              lessThan?: number;
             }
       : T extends Date
         ?
@@ -204,11 +204,11 @@ export namespace RONIN {
                 /**
                  * Matches records where the field is greater than the provided value.
                  */
-                greaterThan?: null | Date;
+                greaterThan?: Date;
                 /**
                  * Matches records where the field is less than the provided value.
                  */
-                lessThan?: null | Date;
+                lessThan?: Date;
               }
         : T extends boolean
           ? {

--- a/src/types/codegen.ts
+++ b/src/types/codegen.ts
@@ -13,8 +13,8 @@ export namespace RONIN {
   export interface RoninMetadata {
     createdAt: Date;
     createdBy: string | Record<string, any>;
-    deletedAt: Date | null;
-    deletedBy: string | Record<string, any> | null;
+    deletedAt: null | Date;
+    deletedBy: null | string | Record<string, any>;
     locked: boolean;
     status: 'draft' | 'published' | 'archived';
     updatedAt: Date;
@@ -24,55 +24,55 @@ export namespace RONIN {
   export interface Blob extends StoredObject {}
 
   interface StringFilterFunction<T, R, O> extends ReducedFunction {
-    (value: T | T[], options?: O): Promise<R>;
+    (value: null | T | T[], options?: O): Promise<R>;
     /**
      * Returns records where the field is not equal to the provided value.
      */
-    notBeing: (value: T | T[], options?: O) => Promise<R>;
+    notBeing: (value: null | T | T[], options?: O) => Promise<R>;
     /**
      * Returns records where the field starts with the provided value.
      */
-    startingWith: (value: T | T[], options?: O) => Promise<R>;
+    startingWith: (value: null | T | T[], options?: O) => Promise<R>;
     /**
      * Returns records where the field ends with the provided value.
      */
-    endingWith: (value: T | T[], options?: O) => Promise<R>;
+    endingWith: (value: null | T | T[], options?: O) => Promise<R>;
     /**
      * Returns records where the field contains the provided value.
      */
-    containing: (value: T | T[], options?: O) => Promise<R>;
+    containing: (value: null | T | T[], options?: O) => Promise<R>;
   }
 
   interface NumberFilterFunction<T, R, O> extends ReducedFunction {
-    (value: T | T[], options?: O): Promise<R>;
+    (value: null | T | T[], options?: O): Promise<R>;
     /**
      * Returns records where the field is not equal to the provided value.
      */
-    notBeing: (value: T | T[], options?: O) => Promise<R>;
+    notBeing: (value: null | T | T[], options?: O) => Promise<R>;
     /**
      * Returns records where the field is greater than the provided value.
      */
-    greaterThan: (value: T | T[], options?: O) => Promise<R>;
+    greaterThan: (value: null | T | T[], options?: O) => Promise<R>;
     /**
      * Returns records where the field is less than the provided value.
      */
-    lessThan: (value: T | T[], options?: O) => Promise<R>;
+    lessThan: (value: null | T | T[], options?: O) => Promise<R>;
   }
 
   interface DateFilterFunction<T, R, O> extends ReducedFunction {
-    (value: T | T[], options?: O): Promise<R>;
+    (value: null | T | T[], options?: O): Promise<R>;
     /**
      * Returns records where the field is not equal to the provided value.
      */
-    notBeing: (value: T | T[], options?: O) => Promise<R>;
+    notBeing: (value: null | T | T[], options?: O) => Promise<R>;
     /**
      * Returns records where the field is greater than the provided value.
      */
-    greaterThan: (value: T | T[], options?: O) => Promise<R>;
+    greaterThan: (value: null | T | T[], options?: O) => Promise<R>;
     /**
      * Returns records where the field is less than the provided value.
      */
-    lessThan: (value: T | T[], options?: O) => Promise<R>;
+    lessThan: (value: null | T | T[], options?: O) => Promise<R>;
   }
 
   interface BooleanFilterFunction<T, R, O> extends ReducedFunction {
@@ -80,7 +80,7 @@ export namespace RONIN {
   }
 
   type RecordFilterFunction<T, R, O> = Omit<ReducedFunction, keyof T> & {
-    (value: string | string[], options?: O): Promise<R>;
+    (value: null | string | string[], options?: O): Promise<R>;
   };
   type RecordFilterObject<T, R, O> = {
     [K in keyof T]: FilterFunction<T[K], R, O>;
@@ -108,7 +108,7 @@ export namespace RONIN {
              * `being` instruction can't be used in combination with other
              * search instructions.
              */
-            being: string | string[];
+            being: null | string | string[];
             notBeing: never;
             startingWith: never;
             endingWith: never;
@@ -119,7 +119,7 @@ export namespace RONIN {
              * `notBeing` instruction can't be used in combination with other
              * search instructions.
              */
-            notBeing: string | string[];
+            notBeing: null | string | string[];
             being: never;
             startingWith: never;
             endingWith: never;
@@ -131,15 +131,15 @@ export namespace RONIN {
             /**
              * Matches records where the field starts with the provided value.
              */
-            startingWith?: string | string[];
+            startingWith?: null | string | string[];
             /**
              * Matches records where the field ends with the provided value.
              */
-            endingWith?: string | string[];
+            endingWith?: null | string | string[];
             /**
              * Matches records where the field contains the provided value.
              */
-            containing?: string | string[];
+            containing?: null | string | string[];
           }
     : T extends number
       ?
@@ -148,7 +148,7 @@ export namespace RONIN {
                * `being` instruction can't be used in combination with other
                * search instructions.
                */
-              being: number | number[];
+              being: null | number | number[];
               notBeing: never;
               greaterThan: never;
               lessThan: never;
@@ -158,7 +158,7 @@ export namespace RONIN {
                * `notBeing` instruction can't be used in combination with other
                * search instructions.
                */
-              notBeing: number | number[];
+              notBeing: null | number | number[];
               being: never;
               greaterThan: never;
               lessThan: never;
@@ -169,11 +169,11 @@ export namespace RONIN {
               /**
                * Matches records where the field is greater than the provided value.
                */
-              greaterThan?: number;
+              greaterThan?: null | number;
               /**
                * Matches records where the field is less than the provided value.
                */
-              lessThan?: number;
+              lessThan?: null | number;
             }
       : T extends Date
         ?
@@ -182,7 +182,7 @@ export namespace RONIN {
                  * `being` instruction can't be used in combination with other
                  * search instructions.
                  */
-                being: Date | Date[];
+                being: null | Date | Date[];
                 notBeing: never;
                 greaterThan: never;
                 lessThan: never;
@@ -192,7 +192,7 @@ export namespace RONIN {
                  * `notBeing` instruction can't be used in combination with other
                  * search instructions.
                  */
-                notBeing: Date | Date[];
+                notBeing: null | Date | Date[];
                 being: never;
                 greaterThan: never;
                 lessThan: never;
@@ -204,11 +204,11 @@ export namespace RONIN {
                 /**
                  * Matches records where the field is greater than the provided value.
                  */
-                greaterThan?: Date;
+                greaterThan?: null | Date;
                 /**
                  * Matches records where the field is less than the provided value.
                  */
-                lessThan?: Date;
+                lessThan?: null | Date;
               }
         : T extends boolean
           ? {
@@ -219,17 +219,18 @@ export namespace RONIN {
             }
           : T extends RONIN.RoninRecord<string>
             ?
+                | null
                 | string
                 | string[]
                 | {
-                    [K in keyof T]: T[K] | Partial<FilterObject<T[K]>>;
+                    [K in keyof T]: null | T[K] | Partial<FilterObject<T[K]>>;
                   }
             : T extends Record<string, any>
-              ? { [K in keyof T]: T[K] | Partial<FilterObject<T[K]>> }
+              ? { [K in keyof T]: null | T[K] | Partial<FilterObject<T[K]>> }
               : never;
 
   export type WithObject<TSchema> = {
-    [K in keyof TSchema]: TSchema[K] | Array<TSchema[K]> | Partial<FilterObject<TSchema[K]>>;
+    [K in keyof TSchema]: null | TSchema[K] | Array<TSchema[K]> | Partial<FilterObject<TSchema[K]>>;
   };
 
   export type WithFilterFunctions<TSchema, R, O = undefined> = {


### PR DESCRIPTION
This pull request adds support for querying records whose fields might be or might not be empty.

```ts
await get.accounts.with.session.notBeing(null);

await get.members.with.account(null);

await get.products.with({
  category: { notBeing: null }
})
```