### PR TITLE
Added option for preventing data hook skipping

### DIFF
--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -39,6 +39,32 @@ export interface QueryHandlerOptions {
    * option is required.
    */
   asyncContext?: AsyncLocalStorage<any>;
+
+  /**
+   * By default, the client tries to intelligently prevent recursions in data
+   * hooks by only executing data hooks that come after the lifecycle level of
+   * the current data hook.
+   *
+   * Additionally, no data hooks will be called for queries inside data hooks
+   * that are addressing the same schema as the surrounding data hook.
+   *
+   * To disable this intelligent recursion prevention, you can disable the
+   * option right here.
+   *
+   * **EXAMPLES**
+   *
+   * - If a query targeting the `customer` schema is executed in the
+   * `beforeCreate` data hook of the `account` schema, only data hooks after
+   * the "before" lifecycle level (such as `set`, `afterSet`, `create`,
+   * `afterCreate` etc.) will be executed for the `customer` query.
+   *
+   * - If a query targeting the `customer` schema is executed in the
+   * `beforeCreate` data hook of the `customer` schema, no data hooks will be
+   * executed for the `customer` query.
+   *
+   * @default true
+   */
+  skipHooks?: boolean;
 }
 
 export type QueryHandlerOptionsFactory = QueryHandlerOptions | (() => QueryHandlerOptions);

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -211,19 +211,15 @@ const invokeHook = async (
     hookArguments[2] = queryResult;
   }
 
-  // In order to make data hooks as easy as possible to use and prevent any
-  // kind of infinite recursion, we would like to ensure that queries inside
-  // data hooks only run data hooks that come after it in the lifecycle.
-  //
-  // Additionally, if the query being run inside the data hook is for the same
-  // schema as the surrounding data hook, not even the data hooks after it in
-  // the lifecycle should run, meaning no data hooks should run at all.
+  // Learn more about this behavior in the comment of the `skipHooks` option.
   const parentHook = asyncContext.getStore();
   const shouldSkip =
-    parentHook &&
-    (HOOK_TYPES.indexOf(hookType) <= HOOK_TYPES.indexOf(parentHook.hookType) ||
-      (query.schema === parentHook.querySchema &&
-        HOOK_TYPES.indexOf(hookType) > HOOK_TYPES.indexOf(parentHook.hookType)));
+    typeof options.skipHooks === 'boolean'
+      ? options.skipHooks
+      : parentHook &&
+        (HOOK_TYPES.indexOf(hookType) <= HOOK_TYPES.indexOf(parentHook.hookType) ||
+          (query.schema === parentHook.querySchema &&
+            HOOK_TYPES.indexOf(hookType) > HOOK_TYPES.indexOf(parentHook.hookType)));
 
   if (hooksForSchema && hookName in hooksForSchema && !shouldSkip) {
     const [instructions, isMultiple, queryResults] = hookArguments;


### PR DESCRIPTION
Check out the description of the newly introduced hook to learn more about its purpose!

I'm adding this hook because the intelligent recursion prevention outlined in the comment does not yet cover all possible cases, so the option can be used as a temporary escape hatch until it does.