### PR TITLE
Merge options instead of replacing them

### DIFF
--- a/src/syntax/handlers.ts
+++ b/src/syntax/handlers.ts
@@ -1,6 +1,6 @@
 import { runQueriesWithStorageAndHooks } from '@/src/queries';
 import type { Query } from '@/src/types/query';
-import type { QueryHandlerOptionsFactory } from '@/src/types/utils';
+import type { QueryHandlerOptions } from '@/src/types/utils';
 
 /**
  * Executes an array of queries and handles their results. It is used to execute
@@ -22,9 +22,7 @@ import type { QueryHandlerOptionsFactory } from '@/src/types/utils';
  * The `RONIN_TOKEN` environment variable will be used (if available) to
  * authenticate requests if the `token` option is not provided.
  */
-export const queriesHandler = async (queries: Query[], optionsFactory: QueryHandlerOptionsFactory = {}) => {
-  const options = typeof optionsFactory === 'function' ? optionsFactory() : optionsFactory;
-
+export const queriesHandler = async (queries: Query[], options: QueryHandlerOptions = {}) => {
   if (!options.token && typeof process !== 'undefined') {
     const token =
       typeof process?.env !== 'undefined'
@@ -72,7 +70,7 @@ export const queriesHandler = async (queries: Query[], optionsFactory: QueryHand
  * );
  * ```
  */
-export const queryHandler = async (query: Query, options: QueryHandlerOptionsFactory) => {
+export const queryHandler = async (query: Query, options: QueryHandlerOptions) => {
   const results = await queriesHandler([query], options);
   return results[0];
 };

--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -1,7 +1,8 @@
 import { queriesHandler, queryHandler } from '@/src/syntax/handlers';
 import { getBatchProxy, getSyntaxProxy } from '@/src/syntax/utils';
 import type { RONIN } from '@/src/types/codegen';
-import type { PromiseTuple, QueryHandlerOptionsFactory } from '@/src/types/utils';
+import type { PromiseTuple, QueryHandlerOptions } from '@/src/types/utils';
+import { mergeOptions } from '@/src/utils/helpers';
 
 /**
  * Creates a syntax factory for generating and executing queries.
@@ -46,21 +47,21 @@ import type { PromiseTuple, QueryHandlerOptionsFactory } from '@/src/types/utils
  * ]);
  * ```
  */
-export const createSyntaxFactory = (options: QueryHandlerOptionsFactory) => ({
+export const createSyntaxFactory = (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => ({
   create: getSyntaxProxy('create', (query, queryOptions) =>
-    queryHandler(query, queryOptions || options),
+    queryHandler(query, mergeOptions(options, queryOptions)),
   ) as RONIN.Creator,
   get: getSyntaxProxy('get', (query, queryOptions) =>
-    queryHandler(query, queryOptions || options),
+    queryHandler(query, mergeOptions(options, queryOptions)),
   ) as RONIN.Getter,
   set: getSyntaxProxy('set', (query, queryOptions) =>
-    queryHandler(query, queryOptions || options),
+    queryHandler(query, mergeOptions(options, queryOptions)),
   ) as RONIN.Setter,
   drop: getSyntaxProxy('drop', (query, queryOptions) =>
-    queryHandler(query, queryOptions || options),
+    queryHandler(query, mergeOptions(options, queryOptions)),
   ) as RONIN.Dropper,
   count: getSyntaxProxy('count', (query, queryOptions) =>
-    queryHandler(query, queryOptions || options),
+    queryHandler(query, mergeOptions(options, queryOptions)),
   ) as RONIN.Counter,
   batch: <T extends [Promise<any>, ...Promise<any>[]] | Promise<any>[]>(
     operations: () => T,
@@ -69,7 +70,7 @@ export const createSyntaxFactory = (options: QueryHandlerOptionsFactory) => ({
     getBatchProxy<T>(operations, batchQueryOptions, (queries, queryOptions) =>
       queriesHandler(
         queries.map(({ query }) => query),
-        queryOptions || batchQueryOptions || options,
+        mergeOptions(options, batchQueryOptions, queryOptions),
       ),
     ) as Promise<PromiseTuple<T>>,
 });

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -67,8 +67,6 @@ export interface QueryHandlerOptions {
   skipHooks?: boolean;
 }
 
-export type QueryHandlerOptionsFactory = QueryHandlerOptions | (() => QueryHandlerOptions);
-
 /**
  * Utility type to make all properties of an object optional.
  */

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,3 +1,5 @@
+import type { QueryHandlerOptions } from '@/src/types/utils';
+
 /**
  * Construct a new object from a "dot string" property accessor.
  *
@@ -155,4 +157,20 @@ export const formatTimeFields = (record: object, timeFields: string[]) => {
   timeFields.forEach((field) =>
     setProperty(record, field, (value: string | null) => (value !== null ? new Date(value) : null)),
   );
+};
+
+/**
+ * Merges a list of option objects and option factories into a single object.
+ *
+ * @param options - An array of option objects or option factories.
+ *
+ * @returns A single option object.
+ */
+export const mergeOptions = (
+  ...options: (undefined | QueryHandlerOptions | (() => QueryHandlerOptions))[]
+): QueryHandlerOptions => {
+  return options.reduce((acc: QueryHandlerOptions, opt) => {
+    const resolvedOpt = typeof opt === 'function' ? opt() : opt;
+    return { ...acc, ...resolvedOpt };
+  }, {});
 };


### PR DESCRIPTION
This change ensures that options provided at a higher level (e.g. when initializing the TS client) are not deleted by options provided on a lower level (e.g. when running a query).

Instead, lower-level options overwrite higher-level options after this change has landed.