### PR TITLE
Export `InvalidQueryError` class

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { runQueriesWithStorageAndHooks as runQueries } from '@/src/queries';
 import { processStorableObjects } from '@/src/storage';
 import { getBatchProxy, getSyntaxProxy } from '@/src/syntax/utils';
+import { InvalidQueryError } from '@/src/utils/errors';
 
-export { runQueries, processStorableObjects, getSyntaxProxy, getBatchProxy };
+export { runQueries, processStorableObjects, getSyntaxProxy, getBatchProxy, InvalidQueryError };


### PR DESCRIPTION
This allows for performing checks for errors outside the client.