### PR TITLE
Added Error Code to InvalidQueryError

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -118,7 +118,7 @@ export const runQueries = async <T>(
           query && path ? `${path.replace(/queries\[\d+\]\./, '')} = ${JSON.stringify(instruction)}` : null,
         path: path,
         details,
-        code: result.error.code,
+        code: result.error.code || null,
       });
     }
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -118,6 +118,7 @@ export const runQueries = async <T>(
           query && path ? `${path.replace(/queries\[\d+\]\./, '')} = ${JSON.stringify(instruction)}` : null,
         path: path,
         details,
+        code: result.error.code,
       });
     }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -3,6 +3,7 @@ interface InvalidQueryErrorDetails {
   query: string | null;
   path: string | null;
   details: string;
+  code: string;
 }
 
 export class InvalidQueryError extends Error {
@@ -10,6 +11,7 @@ export class InvalidQueryError extends Error {
   query: InvalidQueryErrorDetails['query'];
   path: InvalidQueryErrorDetails['path'];
   details: InvalidQueryErrorDetails['details'];
+  code: InvalidQueryErrorDetails['code'];
 
   constructor(details: InvalidQueryErrorDetails) {
     super(details.message);
@@ -19,6 +21,7 @@ export class InvalidQueryError extends Error {
     this.query = details.query;
     this.path = details.path;
     this.details = details.details;
+    this.code = details.code;
   }
 }
 


### PR DESCRIPTION
This PR introduces the passing of an error code to the InvalidQueryError exception. The error code can be consumed by the user for more detailed error handling and debugging.