### PR TITLE
Simplify field types

### DIFF
--- a/src/bin/utils/schema.ts
+++ b/src/bin/utils/schema.ts
@@ -91,8 +91,6 @@ export async function parseSchemaDefinitionFile(
         return 'date';
       case 'Blob':
         return 'blob';
-      case 'Token':
-        return 'token';
       case 'JSON':
         return 'json';
       default: {

--- a/src/bin/utils/schema.ts
+++ b/src/bin/utils/schema.ts
@@ -84,15 +84,11 @@ export async function parseSchemaDefinitionFile(
     const originalType = typeMapping[type] || type;
     switch (originalType) {
       case 'string':
-        return 'text';
       case 'number':
-        return 'number';
       case 'boolean':
-        return 'toggle';
+        return originalType;
       case 'Date':
-        return 'time';
-      case 'RichText':
-        return 'rich-text';
+        return 'date';
       case 'Blob':
         return 'blob';
       case 'Token':
@@ -103,7 +99,7 @@ export async function parseSchemaDefinitionFile(
         const { resolvedTypeName } = resolveTypeAlias(originalType);
 
         if (resolvedTypeName === schemaRecordAlias) {
-          return 'record';
+          return 'reference';
         }
 
         return 'unknown';
@@ -309,7 +305,7 @@ export async function parseSchemaDefinitionFile(
                 const { name, description, details } = parseJsDoc(member);
 
                 let schema: string | null = null;
-                if (fieldType === 'record') {
+                if (fieldType === 'reference') {
                   schema = checkSchemaInclusion(member, typeName);
                 }
                 if (fieldType === 'unknown') {
@@ -336,7 +332,7 @@ export async function parseSchemaDefinitionFile(
                   field.description = description;
                 }
 
-                if (fieldType === 'text') {
+                if (fieldType === 'string') {
                   field.displayAs = 'single-line';
                 }
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -13,12 +13,11 @@ type QueryResponse<T> = {
 type SchemaFieldType =
   | 'list'
   | 'group'
-  | 'record'
-  | 'text'
-  | 'rich-text'
-  | 'time'
+  | 'reference'
+  | 'string'
+  | 'date'
   | 'blob'
-  | 'toggle'
+  | 'boolean'
   | 'number'
   | 'json'
   | 'token';
@@ -124,7 +123,7 @@ export const runQueries = async <T>(
     const timeFields =
       'schema' in result
         ? Object.entries(result.schema)
-            .filter(([, type]) => type === 'time')
+            .filter(([, type]) => type === 'date')
             .map(([name]) => name)
         : [];
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -19,8 +19,7 @@ type SchemaFieldType =
   | 'blob'
   | 'boolean'
   | 'number'
-  | 'json'
-  | 'token';
+  | 'json';
 
 type Result<T> =
   | {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -7,7 +7,7 @@ export type Schema = {
             id: string;
             slug: string;
             name: string;
-            type: 'group' | 'text' | 'rich-text' | 'time' | 'blob' | 'toggle' | 'number' | 'json' | 'token';
+            type: 'group' | 'string' | 'date' | 'blob' | 'boolean' | 'number' | 'json' | 'token';
             required?: boolean | undefined;
             unique?: boolean | undefined;
             displayAs?: 'single-line' | 'multi-line' | undefined;
@@ -24,16 +24,7 @@ export type Schema = {
                   id: string;
                   slug: string;
                   name: string;
-                  type:
-                    | 'group'
-                    | 'text'
-                    | 'rich-text'
-                    | 'time'
-                    | 'blob'
-                    | 'toggle'
-                    | 'number'
-                    | 'json'
-                    | 'token';
+                  type: 'group' | 'string' | 'date' | 'blob' | 'boolean' | 'number' | 'json' | 'token';
                   required?: boolean | undefined;
                   unique?: boolean | undefined;
                 }
@@ -43,7 +34,7 @@ export type Schema = {
                   name: string;
                   required?: boolean | undefined;
                   unique?: boolean | undefined;
-                  type: 'record';
+                  type: 'reference';
                   schema: string | null;
                   space?: string | undefined;
                   action?:
@@ -61,7 +52,7 @@ export type Schema = {
             name: string;
             required?: boolean | undefined;
             unique?: boolean | undefined;
-            type: 'record';
+            type: 'reference';
             schema: string | null;
             space?: string | undefined;
             action?:

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -7,15 +7,26 @@ export type Schema = {
             id: string;
             slug: string;
             name: string;
-            type: 'group' | 'string' | 'date' | 'blob' | 'boolean' | 'number' | 'json' | 'token';
+            description?: string | undefined;
+            type: 'group' | 'time' | 'blob' | 'boolean' | 'number';
             required?: boolean | undefined;
             unique?: boolean | undefined;
-            displayAs?: 'single-line' | 'multi-line' | undefined;
           }
         | {
             id: string;
             slug: string;
             name: string;
+            description?: string | undefined;
+            required?: boolean | undefined;
+            unique?: boolean | undefined;
+            type: 'string';
+            displayAs?: 'single-line' | 'multi-line' | 'secret';
+          }
+        | {
+            id: string;
+            slug: string;
+            name: string;
+            description?: string | undefined;
             required?: boolean | undefined;
             unique?: boolean | undefined;
             type: 'list';
@@ -24,7 +35,8 @@ export type Schema = {
                   id: string;
                   slug: string;
                   name: string;
-                  type: 'group' | 'string' | 'date' | 'blob' | 'boolean' | 'number' | 'json' | 'token';
+                  description?: string | undefined;
+                  type: 'group' | 'time' | 'blob' | 'boolean' | 'number';
                   required?: boolean | undefined;
                   unique?: boolean | undefined;
                 }
@@ -32,6 +44,17 @@ export type Schema = {
                   id: string;
                   slug: string;
                   name: string;
+                  description?: string | undefined;
+                  required?: boolean | undefined;
+                  unique?: boolean | undefined;
+                  type: 'string';
+                  displayAs?: 'single-line' | 'multi-line' | 'secret';
+                }
+              | {
+                  id: string;
+                  slug: string;
+                  name: string;
+                  description?: string | undefined;
                   required?: boolean | undefined;
                   unique?: boolean | undefined;
                   type: 'reference';
@@ -39,10 +62,20 @@ export type Schema = {
                   space?: string | undefined;
                   action?:
                     | {
-                        onDelete: ('cascade' | 'clear' | 'restrict') | null;
-                        onUpdate: ('cascade' | 'clear' | 'restrict') | null;
+                        onDelete: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
+                        onUpdate: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
                       }
                     | undefined;
+                }
+              | {
+                  id: string;
+                  slug: string;
+                  name: string;
+                  description?: string | undefined;
+                  required?: boolean | undefined;
+                  unique?: boolean | undefined;
+                  type: 'json';
+                  displayAs?: 'rich-text' | undefined;
                 }
             )[];
           }
@@ -50,6 +83,7 @@ export type Schema = {
             id: string;
             slug: string;
             name: string;
+            description?: string | undefined;
             required?: boolean | undefined;
             unique?: boolean | undefined;
             type: 'reference';
@@ -57,10 +91,20 @@ export type Schema = {
             space?: string | undefined;
             action?:
               | {
-                  onDelete: ('cascade' | 'clear' | 'restrict') | null;
-                  onUpdate: ('cascade' | 'clear' | 'restrict') | null;
+                  onDelete: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
+                  onUpdate: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
                 }
               | undefined;
+          }
+        | {
+            id: string;
+            slug: string;
+            name: string;
+            description?: string | undefined;
+            required?: boolean | undefined;
+            unique?: boolean | undefined;
+            type: 'json';
+            displayAs?: 'rich-text' | undefined;
           }
       )[]
     | null;

--- a/tests/integration/factory.test.ts
+++ b/tests/integration/factory.test.ts
@@ -540,8 +540,8 @@ describe('factory', () => {
             },
             schema: {
               name: 'string',
-              createdAt: 'time',
-              'ronin.updatedAt': 'time',
+              createdAt: 'date',
+              'ronin.updatedAt': 'date',
             },
           },
           {
@@ -562,8 +562,8 @@ describe('factory', () => {
               },
             ],
             schema: {
-              createdAt: 'time',
-              'ronin.updatedAt': 'time',
+              createdAt: 'date',
+              'ronin.updatedAt': 'date',
               name: 'string',
             },
           },


### PR DESCRIPTION
This pull request simplifies the schema field type by removing non-essential types and renaming essential types to other alternative names that are more commonly understood.

These are the fields that have been renamed or removed:

- `Text` -> `String`
- `Time` -> `Date`
- `Token` -> `String` displayed as `secret`
- `Rich Text` -> `JSON` displayed as `rich-text`
- `Toggle` -> `Boolean`