### PR TITLE
Remove "time" field type and update formatting to use "date"

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -3,7 +3,7 @@ import type { Query, Results } from '@/src/types/query';
 import type { QueryHandlerOptions } from '@/src/types/utils';
 import { runQueriesWithHooks } from '@/src/utils/data-hooks';
 import { getDotNotatedPath, getResponseBody, InvalidQueryError } from '@/src/utils/errors';
-import { formatTimeFields, getProperty } from '@/src/utils/helpers';
+import { formatDateFields, getProperty } from '@/src/utils/helpers';
 
 type QueryResponse<T> = {
   results: Result<T>[];
@@ -119,7 +119,7 @@ export const runQueries = async <T>(
       continue;
     }
 
-    const timeFields =
+    const dateFields =
       'schema' in result
         ? Object.entries(result.schema)
             .filter(([, type]) => type === 'date')
@@ -135,7 +135,7 @@ export const runQueries = async <T>(
         continue;
       }
 
-      formatTimeFields(result.record, timeFields);
+      formatDateFields(result.record, dateFields);
 
       results[i] = result.record;
       continue;
@@ -144,7 +144,7 @@ export const runQueries = async <T>(
     // Handle result with multiple records.
     if ('records' in result) {
       for (const record of result.records) {
-        formatTimeFields(record, timeFields);
+        formatDateFields(record, dateFields);
       }
 
       // Expose the pagination cursors in order to allow for retrieving the

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -8,7 +8,7 @@ export type Schema = {
             slug: string;
             name: string;
             description?: string | undefined;
-            type: 'group' | 'time' | 'blob' | 'boolean' | 'number';
+            type: 'group' | 'date' | 'blob' | 'boolean' | 'number';
             required?: boolean | undefined;
             unique?: boolean | undefined;
           }
@@ -36,7 +36,7 @@ export type Schema = {
                   slug: string;
                   name: string;
                   description?: string | undefined;
-                  type: 'group' | 'time' | 'blob' | 'boolean' | 'number';
+                  type: 'group' | 'date' | 'blob' | 'boolean' | 'number';
                   required?: boolean | undefined;
                   unique?: boolean | undefined;
                 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -148,13 +148,13 @@ export const toDashCase = (string?: string | null): string => {
 };
 
 /**
- * Convert Time fields in a record to JavaScript `Date` objects.
+ * Convert Date fields in a record to JavaScript `Date` objects.
  *
- * @param record - A record to format the Time fields of.
- * @param timeFields - An array of property keys for the time fields.
+ * @param record - A record to format the Date fields of.
+ * @param dateFields - An array of property keys for the date fields.
  */
-export const formatTimeFields = (record: object, timeFields: string[]) => {
-  timeFields.forEach((field) =>
+export const formatDateFields = (record: object, dateFields: string[]) => {
+  dateFields.forEach((field) =>
     setProperty(record, field, (value: string | null) => (value !== null ? new Date(value) : null)),
   );
 };

--- a/tests/integration/factory.test.ts
+++ b/tests/integration/factory.test.ts
@@ -524,7 +524,7 @@ describe('factory', () => {
     );
   });
 
-  test('format time fields', async () => {
+  test('format date fields', async () => {
     const mockFetchNew = mock(async (request) => {
       mockRequestResolvedValue = request;
 


### PR DESCRIPTION
This pull request removes the remaining of the `time` field type that was renamed to `date`.