### PR TITLE
Export option type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,4 +65,4 @@ export type {
 export type { StorableObjectValue, StoredObject } from '@/src/types/storage';
 
 // Other
-export type { PromiseTuple } from '@/src/types/utils';
+export type { PromiseTuple, QueryHandlerOptions } from '@/src/types/utils';


### PR DESCRIPTION
The client can either receive a function that generates its options or the options directly, so it is hard for third-parties to parse out the list of possible options. Let's export the associated type instead.