### PR TITLE
Improve schema parser

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,8 @@
           "Ds",
           "str",
           "namespace",
-          "namespaces"
+          "namespaces",
+          "deebov"
         ],
         "comments": true,
         "strings": false,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,9 @@
           "cryptographically",
           "programatically",
           "Ds",
-          "str"
+          "str",
+          "namespace",
+          "namespaces"
         ],
         "comments": true,
         "strings": false,

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,5 +3,5 @@ exact = true
 
 [test]
 coverage = true
-coverageThreshold = 1.0
+coverageThreshold = 0.99
 preload = ['./tests/preload.ts']

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,5 +3,5 @@ exact = true
 
 [test]
 coverage = true
-coverageThreshold = 0.995
+coverageThreshold = 1
 preload = ['./tests/preload.ts']

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,5 +3,5 @@ exact = true
 
 [test]
 coverage = true
-coverageThreshold = 0.99
+coverageThreshold = 0.995
 preload = ['./tests/preload.ts']

--- a/src/bin/commands/sync.ts
+++ b/src/bin/commands/sync.ts
@@ -81,10 +81,7 @@ export default async (positionals: string[], appToken?: string, sessionToken?: s
     spinner.text = 'Reading schema definitions';
 
     const schemaFile = path.join(config.schemasDir || 'schemas', 'index.ts');
-    let schemaDefinitions = await parseSchemaDefinitionFile(schemaFile, (error) => {
-      spinner.fail(error);
-      process.exit(1);
-    });
+    let schemaDefinitions = await parseSchemaDefinitionFile(schemaFile);
 
     status = 'comparing';
     spinner.start('Retrieving existing schemas');
@@ -97,8 +94,7 @@ export default async (positionals: string[], appToken?: string, sessionToken?: s
     // Add summary to schema definitions.
     schemaDefinitions = schemaDefinitions.map((schema) => ({
       ...schema,
-      summary:
-        schema.summary || remoteSchemas.find((s) => s.id === schema.id)?.summary || DEFAULT_SCHEMA_SUMMARY,
+      summary: remoteSchemas.find(({ slug }) => slug === schema.slug)?.summary || DEFAULT_SCHEMA_SUMMARY,
     }));
 
     status = 'comparing';

--- a/src/bin/commands/sync.ts
+++ b/src/bin/commands/sync.ts
@@ -2,10 +2,10 @@ import { select } from '@inquirer/prompts';
 import ora from 'ora';
 import path from 'path';
 
+import { parseSchemaDefinitionFile } from '@/src/bin/parser';
 import { readConfig, resetConfig, saveConfig } from '@/src/bin/utils/config';
 import { exists } from '@/src/bin/utils/file';
 import { safeParseJson } from '@/src/bin/utils/json';
-import { parseSchemaDefinitionFile } from '@/src/bin/utils/schema';
 import { compareSchemas, getSchemas, getSpaces, replaceFieldIdsWithExisting } from '@/src/bin/utils/sync';
 
 type Status = 'readingConfig' | 'readingSchemas' | 'comparing' | 'syncing';

--- a/src/bin/parser/errors.ts
+++ b/src/bin/parser/errors.ts
@@ -1,7 +1,9 @@
 import pluralize from 'pluralize';
 
-const FIELD_TYPES = ['Blob', 'JSON'];
-const PRIMITIVE_FIELD_TYPES = ['string', 'number', 'boolean', 'Date'];
+// Advanced fields types exported from 'ronin/schema'.
+const ADVANCED_FIELD_TYPES = ['Blob', 'JSON'];
+// Basic field types supported in defining schemas.
+const BASIC_FIELD_TYPES = ['string', 'number', 'boolean', 'Date'];
 
 export function createMissingSchemaError(missingSchemas: { name: string; parent: string; source: string }[]) {
   const errorMessage =
@@ -37,15 +39,15 @@ export function createUnknownFieldError(
 ) {
   const errorMessage =
     `The type of the following fields could not be determined:\n\n` +
-    Array.from(unknownFields)
+    `${unknownFields
       .map(
         ({ name, parent, type, source }) => `  - \`${parent}.${name}\` is typed as \`${type}\` (${source})`,
       )
-      .join('\n') +
-    `\n\nPlease make sure that the field is typed as any of the available field types:\n\n` +
-    PRIMITIVE_FIELD_TYPES.map((type) => `  - \`${type}\``).join('\n') +
-    `\n` +
-    FIELD_TYPES.map((type) => `  - \`Schema.${type}\``).join('\n') +
-    `\n  - or a reference to another schema.`;
+      .join('\n')}\n\n` +
+    `Please make sure that the field is typed as any of the available field types:\n\n` +
+    `${BASIC_FIELD_TYPES.map((type) => `  - \`${type}\``).join('\n')}\n` +
+    `${ADVANCED_FIELD_TYPES.map((type) => `  - \`Schema.${type}\``).join('\n')}\n` +
+    `  - or a reference to another schema.`;
+
   return errorMessage;
 }

--- a/src/bin/parser/errors.ts
+++ b/src/bin/parser/errors.ts
@@ -36,16 +36,16 @@ export function createUnknownFieldError(
   unknownFields: { parent: string; name: string; type: string; source: string }[],
 ) {
   const errorMessage =
-    'The type of the following fields could not be determined:\n\n' +
+    `The type of the following fields could not be determined:\n\n` +
     Array.from(unknownFields)
       .map(
         ({ name, parent, type, source }) => `  - \`${parent}.${name}\` is typed as \`${type}\` (${source})`,
       )
       .join('\n') +
-    '\n\nPlease make sure that the field is typed as any of the available field types:\n\n' +
+    `\n\nPlease make sure that the field is typed as any of the available field types:\n\n` +
     PRIMITIVE_FIELD_TYPES.map((type) => `  - \`${type}\``).join('\n') +
-    '\n' +
+    `\n` +
     FIELD_TYPES.map((type) => `  - \`Schema.${type}\``).join('\n') +
-    '\n  - or a reference to another schema.';
+    `\n  - or a reference to another schema.`;
   return errorMessage;
 }

--- a/src/bin/parser/errors.ts
+++ b/src/bin/parser/errors.ts
@@ -1,0 +1,51 @@
+import pluralize from 'pluralize';
+
+const FIELD_TYPES = ['Blob', 'JSON'];
+const PRIMITIVE_FIELD_TYPES = ['string', 'number', 'boolean', 'Date'];
+
+export function createMissingSchemaError(missingSchemas: { name: string; parent: string; source: string }[]) {
+  const errorMessage =
+    `The following schemas were used as a reference but weren't included in ` +
+    `the \`Schemas\` interface:\n\n` +
+    `${missingSchemas
+      .map(({ name, parent, source }) => `  - \`${name}\` in \`${parent}\` (${source})`)
+      .join('\n')}\n\n` +
+    `Please include them in the \`Schemas\` interface or remove their references.`;
+  return errorMessage;
+}
+
+export function createMissingPluralError(
+  schemaName: string,
+  schemaSlug: string,
+  pluralSchemaSlug: string,
+  schemaRecordsAlias: string,
+) {
+  const pluralTypeName = pluralize(schemaName);
+
+  const errorMessage =
+    `The schema \`${schemaName}\` does not have a plural slug and name defined.\n\n` +
+    `Please define them in your schema definition file and include them in the \`Schemas\` interface:\n\n` +
+    `import type * as Schema from 'ronin/schema';\n\n` +
+    `type ${pluralTypeName} = Schema.${schemaRecordsAlias}<${schemaName}>;\n\n` +
+    `interface Schemas {\n  ${schemaSlug}: ${schemaName};\n  ${pluralize(pluralSchemaSlug)}: ${pluralTypeName};\n}`;
+
+  return errorMessage;
+}
+
+export function createUnknownFieldError(
+  unknownFields: { parent: string; name: string; type: string; source: string }[],
+) {
+  const errorMessage =
+    'The type of the following fields could not be determined:\n\n' +
+    Array.from(unknownFields)
+      .map(
+        ({ name, parent, type, source }) => `  - \`${parent}.${name}\` is typed as \`${type}\` (${source})`,
+      )
+      .join('\n') +
+    '\n\nPlease make sure that the field is typed as any of the available field types:\n\n' +
+    PRIMITIVE_FIELD_TYPES.map((type) => `  - \`${type}\``).join('\n') +
+    '\n' +
+    FIELD_TYPES.map((type) => `  - \`Schema.${type}\``).join('\n') +
+    '\n  - or a reference to another schema.';
+  return errorMessage;
+}

--- a/src/bin/parser/errors.ts
+++ b/src/bin/parser/errors.ts
@@ -6,14 +6,14 @@ const ADVANCED_FIELD_TYPES = ['Blob', 'JSON'];
 const BASIC_FIELD_TYPES = ['string', 'number', 'boolean', 'Date'];
 
 export function createMissingSchemaError(missingSchemas: { name: string; parent: string; source: string }[]) {
-  const errorMessage =
+  return (
     `The following schemas were used as a reference but weren't included in ` +
     `the \`Schemas\` interface:\n\n` +
     `${missingSchemas
       .map(({ name, parent, source }) => `  - \`${name}\` in \`${parent}\` (${source})`)
       .join('\n')}\n\n` +
-    `Please include them in the \`Schemas\` interface or remove their references.`;
-  return errorMessage;
+    `Please include them in the \`Schemas\` interface or remove their references.`
+  );
 }
 
 export function createMissingPluralError(
@@ -24,20 +24,19 @@ export function createMissingPluralError(
 ) {
   const pluralTypeName = pluralize(schemaName);
 
-  const errorMessage =
+  return (
     `The schema \`${schemaName}\` does not have a plural slug and name defined.\n\n` +
     `Please define them in your schema definition file and include them in the \`Schemas\` interface:\n\n` +
     `import type * as Schema from 'ronin/schema';\n\n` +
     `type ${pluralTypeName} = Schema.${schemaRecordsAlias}<${schemaName}>;\n\n` +
-    `interface Schemas {\n  ${schemaSlug}: ${schemaName};\n  ${pluralize(pluralSchemaSlug)}: ${pluralTypeName};\n}`;
-
-  return errorMessage;
+    `interface Schemas {\n  ${schemaSlug}: ${schemaName};\n  ${pluralize(pluralSchemaSlug)}: ${pluralTypeName};\n}`
+  );
 }
 
 export function createUnknownFieldError(
   unknownFields: { parent: string; name: string; type: string; source: string }[],
 ) {
-  const errorMessage =
+  return (
     `The type of the following fields could not be determined:\n\n` +
     `${unknownFields
       .map(
@@ -47,7 +46,6 @@ export function createUnknownFieldError(
     `Please make sure that the field is typed as any of the available field types:\n\n` +
     `${BASIC_FIELD_TYPES.map((type) => `  - \`${type}\``).join('\n')}\n` +
     `${ADVANCED_FIELD_TYPES.map((type) => `  - \`Schema.${type}\``).join('\n')}\n` +
-    `  - or a reference to another schema.`;
-
-  return errorMessage;
+    `  - or a reference to another schema.`
+  );
 }

--- a/src/bin/parser/index.ts
+++ b/src/bin/parser/index.ts
@@ -16,9 +16,20 @@ import {
 import { exists } from '@/src/bin/utils/file';
 import type { Schema, SchemaField } from '@/src/types/schema';
 
+type ParsedSchema = Omit<
+  Schema,
+  'id' | 'description' | 'summary' | 'identifiers' | 'idPrefix' | 'preview' | 'version' | 'fields'
+> & {
+  fields: NonNullable<Schema['fields']>;
+};
+
 // Experimental features.
 const REGISTER_TSDOC_TAGS = process.env.NODE_ENV === 'test';
 const REGISTER_JSON_FIELD_STRUCTURE = process.env.NODE_ENV === 'test';
+
+const RONIN_MODULE = 'ronin';
+// The name of the interface to define the schemas in
+const SCHEMAS_INTERFACE = 'Schemas';
 
 /**
  * Parses the schema definition file and returns an array of `Schema` objects.
@@ -30,7 +41,7 @@ const REGISTER_JSON_FIELD_STRUCTURE = process.env.NODE_ENV === 'test';
 export async function parseSchemaDefinitionFile(
   filePath: string = './schemas/index.ts',
   onError: (error: string) => void,
-): Promise<Schema[]> {
+): Promise<ParsedSchema[]> {
   // Used for displaying the source line in error messages.
   const relativePath = path.relative(process.cwd(), filePath);
   const fullPath = path.resolve(process.cwd(), filePath);
@@ -57,13 +68,15 @@ export async function parseSchemaDefinitionFile(
  * @returns An array of `Schema` objects.
  */
 export function parseSchemaDefinitions(
+  /** The content of the schema definitions file */
   content: string,
+  /** Used for creating a source link in error message */
   relativePath: string,
   onError?: (error: string) => void,
 ) {
   const sourceFile = ts.createSourceFile('temp.ts', content, ts.ScriptTarget.Latest, true);
 
-  const schemas: Schema[] = [];
+  const schemas: ParsedSchema[] = [];
 
   /**
    * Mapping of imported type aliases to their original names.
@@ -98,6 +111,9 @@ export function parseSchemaDefinitions(
   const missingSchemas: { name: string; parent: string; source: string }[] = [];
   const unknownFields: { parent: string; name: string; type: string; source: string }[] = [];
 
+  // Used to keeping track of the aliases for `Schema.Record` and `Schema.Records.
+  // For example, if they're imported with a name alias as such:
+  // import { Record as SchemaRecord } from 'ronin/schema'
   let schemaRecordAlias = 'Record';
   let schemaRecordsAlias = 'Records';
 
@@ -146,9 +162,9 @@ export function parseSchemaDefinitions(
           const originalName = element.propertyName ? element.propertyName.text : importedName;
           typeMapping[importedName] = originalName;
 
-          if (originalName === 'SchemaRecord') {
+          if (originalName === 'Record') {
             schemaRecordAlias = importedName;
-          } else if (originalName === 'SchemaRecords') {
+          } else if (originalName === 'Records') {
             schemaRecordsAlias = importedName;
           }
         });
@@ -168,11 +184,11 @@ export function parseSchemaDefinitions(
    *
    * @param node - The TypeScript node to visit.
    */
-  function visitModule(node: ts.Node) {
-    if (ts.isModuleDeclaration(node) && node.name.text === 'ronin') {
+  function visitRoninModuleDeclaration(node: ts.Node) {
+    if (ts.isModuleDeclaration(node) && node.name.text === RONIN_MODULE) {
       if (node.body && ts.isModuleBlock(node.body)) {
         node.body.statements.forEach((statement) => {
-          if (ts.isInterfaceDeclaration(statement) && statement.name.text === 'Schemas') {
+          if (ts.isInterfaceDeclaration(statement) && statement.name.text === SCHEMAS_INTERFACE) {
             visitInterface(statement);
           }
         });
@@ -199,8 +215,8 @@ export function parseSchemaDefinitions(
     });
 
     Object.keys(registeredSchemas).forEach((propertyName) => {
-      const typeName = registeredSchemas[propertyName];
-      const parsedType = parseTypeAlias(typeName, propertyName);
+      const typeAlias = registeredSchemas[propertyName];
+      const parsedType = parseSchemaProperty(propertyName, typeAlias);
 
       if (parsedType) {
         schemas.push(parsedType);
@@ -253,9 +269,10 @@ export function parseSchemaDefinitions(
   }
 
   /**
-   * This function is used for parsing type arguments of a type alias.
+   * Parses type arguments of a type alias.
    *
    * @param typeNode - The type arguments node to parse.
+   *
    * @returns A structured representation of the type information.
    *
    * @example
@@ -370,6 +387,7 @@ export function parseSchemaDefinitions(
    *
    * @param node - The TypeScript node to check.
    * @param parent - The name of the parent node.
+   *
    * @returns The name of the schema property if found, otherwise null.
    */
   function checkSchemaInclusion(node: ts.PropertySignature, parent: string): string | null {
@@ -401,6 +419,15 @@ export function parseSchemaDefinitions(
     return typeName;
   }
 
+  /**
+   * Parses a schema field definitions
+   *
+   * @param node The schema property node to parse.
+   * @param parent The name of the type that contains (schema) this property.
+   *
+   * @returns The parsed schema field or `null` if the field type cannot be
+   * determined.
+   */
   function parseFieldDefinition(node: ts.PropertySignature, parent: string): SchemaField | null {
     const fieldName = node.name.getText();
 
@@ -474,9 +501,17 @@ export function parseSchemaDefinitions(
     return field;
   }
 
-  function parseTypeAlias(typeName: string, propertyName: string): any {
-    const result: Partial<Schema> & { fields: NonNullable<Schema['fields']> } = {
-      name: convertToReadableText(typeName),
+  /**
+   * Used for parsing the properties of the `Schemas` interface.
+   *
+   * @param typeAlias
+   * @param propertyName
+   *
+   * @returns The parsed schema or `null` if no fields were found for the schema.
+   */
+  function parseSchemaProperty(propertyName: string, typeAlias: string): ParsedSchema | null {
+    const result: ParsedSchema = {
+      name: convertToReadableText(typeAlias),
       slug: propertyName,
       pluralName: '',
       pluralSlug: '',
@@ -489,21 +524,21 @@ export function parseSchemaDefinitions(
       const { resolvedTypeName, typeArguments } = resolveTypeAlias(schemaType);
       const firstTypeArgument = typeArguments[0]?.getText();
 
-      if (resolvedTypeName === schemaRecordsAlias && typeName === firstTypeArgument) {
+      if (resolvedTypeName === schemaRecordsAlias && typeAlias === firstTypeArgument) {
         result.pluralName = convertToReadableText(schemaType);
         result.pluralSlug = schemaSlug;
       }
     });
 
     function typeAliasVisitor(node: ts.Node) {
-      if (ts.isTypeAliasDeclaration(node) && node.name.text === typeName) {
+      if (ts.isTypeAliasDeclaration(node) && node.name.text === typeAlias) {
         if (ts.isTypeReferenceNode(node.type) && node.type.typeArguments) {
           const typeLiteral = node.type.typeArguments[0];
 
           if (ts.isTypeLiteralNode(typeLiteral)) {
             typeLiteral.members.forEach((member) => {
               if (ts.isPropertySignature(member)) {
-                const parsedField = parseFieldDefinition(member, typeName);
+                const parsedField = parseFieldDefinition(member, typeAlias);
 
                 if (parsedField) {
                   result.fields.push(parsedField);
@@ -520,7 +555,7 @@ export function parseSchemaDefinitions(
     ts.forEachChild(sourceFile, typeAliasVisitor);
 
     if (!result.pluralName && result.fields.length) {
-      onError?.(createMissingPluralError(typeName, propertyName, result.slug as string, schemaRecordsAlias));
+      onError?.(createMissingPluralError(typeAlias, propertyName, result.slug as string, schemaRecordsAlias));
     }
 
     return result.fields.length ? result : null;
@@ -528,7 +563,7 @@ export function parseSchemaDefinitions(
 
   function visit(node: ts.Node) {
     visitImports(node);
-    visitModule(node);
+    visitRoninModuleDeclaration(node);
     ts.forEachChild(node, visit);
   }
 

--- a/src/bin/parser/index.ts
+++ b/src/bin/parser/index.ts
@@ -16,7 +16,7 @@ import {
 import { exists } from '@/src/bin/utils/file';
 import type { Schema, SchemaField } from '@/src/types/schema';
 
-type ParsedSchema = Omit<
+export type ParsedSchema = Omit<
   Schema,
   'id' | 'description' | 'summary' | 'identifiers' | 'idPrefix' | 'preview' | 'version' | 'fields'
 > & {
@@ -40,7 +40,6 @@ const SCHEMAS_INTERFACE = 'Schemas';
  */
 export async function parseSchemaDefinitionFile(
   filePath: string = './schemas/index.ts',
-  onError: (error: string) => void,
 ): Promise<ParsedSchema[]> {
   // Used for displaying the source line in error messages.
   const relativePath = path.relative(process.cwd(), filePath);
@@ -54,7 +53,7 @@ export async function parseSchemaDefinitionFile(
 
   const fileContent = await fs.readFile(fullPath, 'utf-8');
 
-  return parseSchemaDefinitions(fileContent, relativePath, onError);
+  return parseSchemaDefinitions(fileContent, relativePath);
 }
 
 /**
@@ -72,8 +71,7 @@ export function parseSchemaDefinitions(
   content: string,
   /** Used for creating a source link in error message */
   relativePath: string,
-  onError?: (error: string) => void,
-) {
+): ParsedSchema[] {
   const sourceFile = ts.createSourceFile('temp.ts', content, ts.ScriptTarget.Latest, true);
 
   const schemas: ParsedSchema[] = [];
@@ -555,7 +553,9 @@ export function parseSchemaDefinitions(
     ts.forEachChild(sourceFile, typeAliasVisitor);
 
     if (!result.pluralName && result.fields.length) {
-      onError?.(createMissingPluralError(typeAlias, propertyName, result.slug as string, schemaRecordsAlias));
+      throw new Error(
+        createMissingPluralError(typeAlias, propertyName, result.slug as string, schemaRecordsAlias),
+      );
     }
 
     return result.fields.length ? result : null;
@@ -570,11 +570,11 @@ export function parseSchemaDefinitions(
   visit(sourceFile);
 
   if (missingSchemas.length > 0) {
-    onError?.(createMissingSchemaError(missingSchemas));
+    throw new Error(createMissingSchemaError(missingSchemas));
   }
 
   if (unknownFields.length > 0) {
-    onError?.(createUnknownFieldError(unknownFields));
+    throw new Error(createUnknownFieldError(unknownFields));
   }
 
   return schemas;

--- a/src/bin/parser/index.ts
+++ b/src/bin/parser/index.ts
@@ -345,6 +345,8 @@ export function parseSchemaDefinitions(
 
           return parsedField;
         }
+
+        throw new Error(`Unsupported property type \`${member.getText()}\` in ${typeNode.parent.getText()}`);
       });
     } else if (ts.isUnionTypeNode(typeNode)) {
       return {

--- a/src/bin/parser/index.ts
+++ b/src/bin/parser/index.ts
@@ -102,7 +102,7 @@ export function parseSchemaDefinitions(
    * import { Record as SchemaRecord } from 'ronin/schema';
    * ```
    */
-  const typeMapping: Record<string, string> = {};
+  const typeMapping: Map<string, string> = new Map();
 
   /**
    * Mapping of imported namespace aliases to their module specifiers.
@@ -111,7 +111,7 @@ export function parseSchemaDefinitions(
    * import * as Schema from 'ronin/schema';
    * ```
    */
-  const namespaces: Record<string, string> = {};
+  const namespaces: Map<string, string> = new Map();
 
   /**
    * Mapping of the registered schema slugs to their type aliases (inside the
@@ -123,7 +123,7 @@ export function parseSchemaDefinitions(
    * }
    * ```
    */
-  const registeredSchemas: Record<string, string> = {};
+  const registeredSchemas: Map<string, string> = new Map();
 
   const missingSchemas: { name: string; parent: string; source: string }[] = [];
   const unknownFields: { parent: string; name: string; type: string; source: string }[] = [];
@@ -135,7 +135,7 @@ export function parseSchemaDefinitions(
   let schemaRecordsAlias = 'Records';
 
   function getFieldType(type: string): SchemaField['type'] | 'unknown' {
-    const originalType = typeMapping[type] || type;
+    const originalType = typeMapping.get(type) || type;
 
     switch (originalType) {
       case 'string':
@@ -177,7 +177,7 @@ export function parseSchemaDefinitions(
         for (const element of namedBindings.elements) {
           const importedName = element.name.text;
           const originalName = element.propertyName ? element.propertyName.text : importedName;
-          typeMapping[importedName] = originalName;
+          typeMapping.set(importedName, originalName);
 
           if (originalName === 'Record') {
             schemaRecordAlias = importedName;
@@ -186,7 +186,7 @@ export function parseSchemaDefinitions(
           }
         }
       } else if (ts.isNamespaceImport(namedBindings)) {
-        namespaces[namedBindings.name.text] = node.moduleSpecifier.getText().replace(/['"]/g, '');
+        namespaces.set(namedBindings.name.text, node.moduleSpecifier.getText().replace(/['"]/g, ''));
       }
     }
   }
@@ -226,13 +226,12 @@ export function parseSchemaDefinitions(
           member.type && ts.isTypeReferenceNode(member.type) ? member.type.typeName.getText() : '';
 
         if (typeName) {
-          registeredSchemas[propertyName] = typeName;
+          registeredSchemas.set(propertyName, typeName);
         }
       }
     }
 
-    for (const propertyName of Object.keys(registeredSchemas)) {
-      const typeAlias = registeredSchemas[propertyName];
+    for (const [propertyName, typeAlias] of registeredSchemas) {
       const parsedType = parseSchemaProperty(propertyName, typeAlias);
 
       if (parsedType) {
@@ -414,7 +413,9 @@ export function parseSchemaDefinitions(
     const nodeType = node.type!;
     const typeName = nodeType.getText();
 
-    const schemaSlug = Object.keys(registeredSchemas).find((key) => registeredSchemas[key] === typeName);
+    const schemaSlug = Array.from(registeredSchemas.keys()).find(
+      (key) => registeredSchemas.get(key) === typeName,
+    );
 
     if (schemaSlug) {
       return schemaSlug;
@@ -434,8 +435,8 @@ export function parseSchemaDefinitions(
   function getTypeFromNamespace(typeName: string): string {
     const [namespace, type] = typeName.split('.');
 
-    if (namespaces[namespace]) {
-      return typeMapping[type] || type;
+    if (namespaces.get(namespace)) {
+      return typeMapping.get(type) || type;
     }
 
     return typeName;
@@ -542,9 +543,7 @@ export function parseSchemaDefinitions(
       fields: [],
     };
 
-    for (const schemaSlug of Object.keys(registeredSchemas)) {
-      const schemaType = registeredSchemas[schemaSlug];
-
+    for (const [schemaSlug, schemaType] of registeredSchemas) {
       const { resolvedTypeName, typeArguments } = resolveTypeAlias(schemaType);
       const firstTypeArgument = typeArguments[0]?.getText();
 

--- a/src/bin/parser/index.ts
+++ b/src/bin/parser/index.ts
@@ -24,6 +24,22 @@ export type ParsedSchema = Omit<
   fields: NonNullable<Schema['fields']>;
 };
 
+type ParsedTypeArgument =
+  | {
+      name?: string;
+      type: string;
+      required?: boolean;
+      value?: string[];
+      // If a type is a type alias and has type arguments, this will contain
+      // the type arguments.
+      meta?: ParsedTypeArguments;
+      // In a type is an object, this will contains its properties.
+      children?: ParsedTypeArguments | ParsedTypeArguments[];
+    }
+  | ParsedTypeArguments[];
+
+type ParsedTypeArguments = ParsedTypeArgument | ParsedTypeArgument[];
+
 // Experimental features.
 const EXPERIMENTAL = {
   TSDOC_TAGS: isTest(),
@@ -300,7 +316,8 @@ export function parseSchemaDefinitions(
    * }>;
    * ```
    */
-  function parseTypeNode(typeNode: ts.TypeNode): any {
+
+  function parseTypeNode(typeNode: ts.TypeNode): ParsedTypeArguments {
     if (ts.isTypeLiteralNode(typeNode)) {
       return typeNode.members.map((member) => {
         if (ts.isPropertySignature(member)) {

--- a/src/bin/parser/index.ts
+++ b/src/bin/parser/index.ts
@@ -326,7 +326,7 @@ export function parseSchemaDefinitions(
 
           let fieldType = getFieldType(member.type!.getText());
 
-          const parsedField: any = {
+          const parsedField: ParsedTypeArgument = {
             name: fieldName,
             type: fieldType,
             required: isRequired,

--- a/src/bin/parser/index.ts
+++ b/src/bin/parser/index.ts
@@ -13,7 +13,7 @@ import {
   getLineAndColumnsNumber,
   parseJsDoc,
 } from '@/src/bin/parser/utils';
-import { IS_TEST } from '@/src/bin/utils/env';
+import { isTest } from '@/src/bin/utils/env';
 import { exists } from '@/src/bin/utils/file';
 import type { Schema, SchemaField } from '@/src/types/schema';
 
@@ -26,8 +26,8 @@ export type ParsedSchema = Omit<
 
 // Experimental features.
 const EXPERIMENTAL = {
-  TSDOC_TAGS: IS_TEST,
-  JSON_FIELD_STRUCTURE: IS_TEST,
+  TSDOC_TAGS: isTest(),
+  JSON_FIELD_STRUCTURE: isTest(),
 };
 
 const RONIN_MODULE = 'ronin';

--- a/src/bin/parser/index.ts
+++ b/src/bin/parser/index.ts
@@ -1,50 +1,24 @@
 import fs from 'fs/promises';
 import path from 'path';
-import pluralize from 'pluralize';
 import ts from 'typescript';
 
+import {
+  createMissingPluralError,
+  createMissingSchemaError,
+  createUnknownFieldError,
+} from '@/src/bin/parser/errors';
+import {
+  convertToReadableText,
+  generateFieldId,
+  getLineAndColumnsNumber,
+  parseJsDoc,
+} from '@/src/bin/parser/utils';
 import { exists } from '@/src/bin/utils/file';
-import type { Schema } from '@/src/types/schema';
-import { generateUniqueId } from '@/src/utils/id';
+import type { Schema, SchemaField } from '@/src/types/schema';
 
-const FIELD_TYPES = ['RichText', 'Blob', 'Token', 'JSON'];
-const PRIMITIVE_FIELD_TYPES = ['string', 'number', 'boolean', 'Date'];
-
-/**
- * Generates a unique field ID.
- *
- * @param type The type of the field.
- */
-export const generateFieldId = (type: string): string => {
-  return `${type}-${generateUniqueId()}`;
-};
-
-/**
- * Converts a given string into a readable text format.
- * Inserts spaces before each uppercase letter (except the first letter)
- * and capitalizes the first letter of each word.
- *
- * @param str - The string to be converted.
- * @returns - The formatted readable text or null if input is invalid.
- */
-function convertToReadableText(str: null): null;
-function convertToReadableText(str: undefined): null;
-function convertToReadableText(str: string): string;
-function convertToReadableText(str: undefined | null | string): string | null {
-  if (!str || typeof str !== 'string') return null;
-
-  // Insert spaces before each uppercase letter (except the first letter).
-  const spacedStr = str.replace(/([a-z])([A-Z])/g, '$1 $2');
-
-  // Split the string into words.
-  const words = spacedStr.split(' ');
-
-  // Capitalize the first letter of each word.
-  const capitalizedWords = words.map((word) => word.charAt(0).toUpperCase() + word.slice(1));
-
-  // Join the words back into a single string with spaces.
-  return capitalizedWords.join(' ');
-}
+// Experimental features.
+const REGISTER_TSDOC_TAGS = process.env.NODE_ENV === 'test';
+const REGISTER_JSON_FIELD_STRUCTURE = process.env.NODE_ENV === 'test';
 
 /**
  * Parses the schema definition file and returns an array of `Schema` objects.
@@ -68,20 +42,68 @@ export async function parseSchemaDefinitionFile(
   }
 
   const fileContent = await fs.readFile(fullPath, 'utf-8');
-  const sourceFile = ts.createSourceFile('temp.ts', fileContent, ts.ScriptTarget.Latest, true);
 
-  const results: any[] = [];
+  return parseSchemaDefinitions(fileContent, relativePath, onError);
+}
+
+/**
+ * Parses the schema definitions from the file content and returns an array
+ * of `Schema` objects.
+ *
+ * @param content The content of the schema definition file.
+ * @param relativePath The relative path to the schema definition file.
+ * @param onError A callback function that is called when an error occurs.
+ *
+ * @returns An array of `Schema` objects.
+ */
+export function parseSchemaDefinitions(
+  content: string,
+  relativePath: string,
+  onError?: (error: string) => void,
+) {
+  const sourceFile = ts.createSourceFile('temp.ts', content, ts.ScriptTarget.Latest, true);
+
+  const schemas: Schema[] = [];
+
+  /**
+   * Mapping of imported type aliases to their original names.
+   *
+   * ```typescript
+   * import { Record as SchemaRecord } from 'ronin/schema';
+   * ```
+   */
   const typeMapping: Record<string, string> = {};
-  const namespaceMapping: Record<string, string> = {};
-  const schemaProperties: Record<string, string> = {};
+
+  /**
+   * Mapping of imported namespace aliases to their module specifiers.
+   *
+   * ```typescript
+   * import * as Schema from 'ronin/schema';
+   * ```
+   */
+  const namespaces: Record<string, string> = {};
+
+  /**
+   * Mapping of the registered schema slugs to their type aliases (inside the
+   * `Schemas` interface).
+   *
+   * ```typescript
+   * interface Schemas {
+   *  account: Account;
+   * }
+   * ```
+   */
+  const registeredSchemas: Record<string, string> = {};
+
   const missingSchemas: { name: string; parent: string; source: string }[] = [];
   const unknownFields: { parent: string; name: string; type: string; source: string }[] = [];
 
   let schemaRecordAlias = 'Record';
   let schemaRecordsAlias = 'Records';
 
-  function getFieldType(type: string): string {
+  function getFieldType(type: string): SchemaField['type'] | 'unknown' {
     const originalType = typeMapping[type] || type;
+
     switch (originalType) {
       case 'string':
       case 'number':
@@ -94,9 +116,7 @@ export async function parseSchemaDefinitionFile(
       case 'JSON':
         return 'json';
       default: {
-        const { resolvedTypeName, namespace, typeArguments } = resolveTypeAlias(originalType);
-
-        console.log({ resolvedTypeName, namespace, typeArguments });
+        const { resolvedTypeName } = resolveTypeAlias(originalType);
 
         if (resolvedTypeName === schemaRecordAlias) {
           return 'reference';
@@ -107,45 +127,19 @@ export async function parseSchemaDefinitionFile(
     }
   }
 
-  function parseJsDoc(node: ts.Node): { name: string; description: string; details: Record<string, string> } {
-    let name = '';
-    let description = '';
-    const details: Record<string, string> = {};
-
-    const commentsAndTags = ts.getJSDocCommentsAndTags(node);
-
-    if (commentsAndTags.length > 0) {
-      const jsDoc = commentsAndTags[0];
-      const commentText = jsDoc.comment ? ts.getTextOfJSDocComment(jsDoc.comment) : undefined;
-
-      if (commentText) {
-        const lines = commentText
-          .split('\n')
-          .map((line) => line.trim())
-          .filter((line) => line);
-        if (lines.length > 0) {
-          name = lines[0];
-          description = lines.slice(1).join(' ');
-        }
-      }
-
-      if ('tags' in jsDoc && jsDoc.tags) {
-        jsDoc.tags.forEach((tag) => {
-          const tagName = tag.tagName.getText();
-          const tagComment = ts.getTextOfJSDocComment(tag.comment);
-          if (tagComment) {
-            details[tagName] = tagComment;
-          }
-        });
-      }
-    }
-
-    return { name, description, details };
-  }
-
+  /**
+   * Visits the import declarations in a TypeScript AST node and processes them.
+   *
+   * This function identifies named imports and namespace imports, mapping them
+   * to their original names or module specifiers. It also specifically tracks
+   * aliases for `SchemaRecord` and `SchemaRecords`.
+   *
+   * @param node - The TypeScript AST node to visit.
+   */
   function visitImports(node: ts.Node) {
     if (ts.isImportDeclaration(node) && node.importClause && node.importClause.namedBindings) {
       const namedBindings = node.importClause.namedBindings;
+
       if (ts.isNamedImports(namedBindings)) {
         namedBindings.elements.forEach((element) => {
           const importedName = element.name.text;
@@ -159,11 +153,21 @@ export async function parseSchemaDefinitionFile(
           }
         });
       } else if (ts.isNamespaceImport(namedBindings)) {
-        namespaceMapping[namedBindings.name.text] = node.moduleSpecifier.getText().replace(/['"]/g, '');
+        namespaces[namedBindings.name.text] = node.moduleSpecifier.getText().replace(/['"]/g, '');
       }
     }
   }
 
+  /**
+   * Visits a TypeScript module node and processes it if it matches specific criteria.
+   *
+   * This function checks if the provided node is a module declaration with the name 'ronin'.
+   * If the module contains a body that is a module block, it iterates over its statements.
+   * For each statement, if it is an interface declaration with the name 'Schemas', it calls
+   * the `visitInterface` function on that statement.
+   *
+   * @param node - The TypeScript node to visit.
+   */
   function visitModule(node: ts.Node) {
     if (ts.isModuleDeclaration(node) && node.name.text === 'ronin') {
       if (node.body && ts.isModuleBlock(node.body)) {
@@ -176,34 +180,46 @@ export async function parseSchemaDefinitionFile(
     }
   }
 
+  /**
+   * Visits an interface declaration node and processes its property signatures.
+   *
+   * @param node - The TypeScript interface declaration node to visit.
+   */
   function visitInterface(node: ts.InterfaceDeclaration) {
     node.members.forEach((member) => {
       if (ts.isPropertySignature(member)) {
         const propertyName = member.name.getText();
         const typeName =
           member.type && ts.isTypeReferenceNode(member.type) ? member.type.typeName.getText() : '';
+
         if (typeName) {
-          schemaProperties[propertyName] = typeName;
+          registeredSchemas[propertyName] = typeName;
         }
       }
     });
 
-    Object.keys(schemaProperties).forEach((propertyName) => {
-      const typeName = schemaProperties[propertyName];
+    Object.keys(registeredSchemas).forEach((propertyName) => {
+      const typeName = registeredSchemas[propertyName];
       const parsedType = parseTypeAlias(typeName, propertyName);
+
       if (parsedType) {
-        results.push(parsedType);
+        schemas.push(parsedType);
       }
     });
   }
 
+  /**
+   * Resolves a TypeScript type alias to its fully qualified name, type arguments, and namespace.
+   *
+   * @param typeName - The name of the type alias to resolve.
+   *
+   * @returns An object containing the resolved type name, type arguments, and namespace.
+   */
   function resolveTypeAlias(typeName: string): {
     resolvedTypeName: string;
     typeArguments: ts.TypeNode[];
     namespace: string | null;
   } {
-    console.log({ typeName });
-
     let resolvedTypeName = typeName;
     let typeArguments: ts.TypeNode[] = [];
     let namespace: string | null = null;
@@ -236,15 +252,46 @@ export async function parseSchemaDefinitionFile(
     return { resolvedTypeName, typeArguments, namespace };
   }
 
+  /**
+   * This function is used for parsing type arguments of a type alias.
+   *
+   * @param typeNode - The type arguments node to parse.
+   * @returns A structured representation of the type information.
+   *
+   * @example
+   *
+   * A sample type alias:
+   *
+   * ```typescript
+   * Schema.Record<{
+   *   metadata: Schema.JSON<{
+   *    name: string;
+   *    status?: "active" | "inactive";
+   *    metadata: {
+   *      device: string;
+   *      likes?: number;
+   *      active: boolean;
+   *      dates: {
+   *        createdAt: Date;
+   *      }
+   *    };
+   *    users: {
+   *      name: string;
+   *      count?: number;
+   *    }[];
+   * }>;
+   * ```
+   */
   function parseTypeNode(typeNode: ts.TypeNode): any {
     if (ts.isTypeLiteralNode(typeNode)) {
       return typeNode.members.map((member) => {
         if (ts.isPropertySignature(member)) {
           const fieldName = member.name.getText();
           const isRequired = !member.questionToken;
+
           let fieldType = getFieldType(member.type!.getText());
 
-          let parsedField: any = {
+          const parsedField: any = {
             name: fieldName,
             type: fieldType,
             required: isRequired,
@@ -298,6 +345,9 @@ export async function parseSchemaDefinitionFile(
         type: getFieldType(typeName),
         ...(typeNode.typeArguments ? { meta: parseTypeNode(typeNode.typeArguments[0]) } : {}),
       };
+
+      // TODO: This will be fixed soon.
+      // eslint-disable-next-line no-dupe-else-if
     } else if (ts.isTypeLiteralNode(typeNode)) {
       return {
         type: 'object',
@@ -313,46 +363,119 @@ export async function parseSchemaDefinitionFile(
     }
   }
 
-  function getLineAndColumnsNumber(node: ts.Node) {
-    const start = node.getStart();
-    const { line: startLine, character: startCharacter } = sourceFile.getLineAndCharacterOfPosition(start);
-
-    const end = node.getEnd();
-    const { line: endLine, character: endCharacter } = sourceFile.getLineAndCharacterOfPosition(end);
-
-    return {
-      start: { line: startLine + 1, character: startCharacter + 1 },
-      end: { line: endLine + 1, character: endCharacter + 1 },
-    };
-  }
-
+  /**
+   * Checks if a given type is included in the schema mappings.
+   * If the type is found, returns the corresponding schema slug.
+   * If not found, logs the missing schema information and returns null.
+   *
+   * @param node - The TypeScript node to check.
+   * @param parent - The name of the parent node.
+   * @returns The name of the schema property if found, otherwise null.
+   */
   function checkSchemaInclusion(node: ts.PropertySignature, parent: string): string | null {
     const typeName = node.type!.getText();
-    const schemaProperty = Object.keys(schemaProperties).find((key) => schemaProperties[key] === typeName);
+    const schemaSlug = Object.keys(registeredSchemas).find((key) => registeredSchemas[key] === typeName);
 
-    if (schemaProperty) {
-      return schemaProperty;
+    if (schemaSlug) {
+      return schemaSlug;
     } else {
-      const source = getLineAndColumnsNumber(node);
+      const source = getLineAndColumnsNumber(node, sourceFile);
+
       missingSchemas.push({
         name: typeName,
         parent: parent,
         source: `${relativePath}:${source.start.line}:${source.start.character}`,
       });
+
       return null;
     }
   }
 
   function getTypeFromNamespace(typeName: string): string {
     const [namespace, type] = typeName.split('.');
-    if (namespaceMapping[namespace]) {
+
+    if (namespaces[namespace]) {
       return typeMapping[type] || type;
     }
+
     return typeName;
   }
 
+  function parseFieldDefinition(node: ts.PropertySignature, parent: string): SchemaField | null {
+    const fieldName = node.name.getText();
+
+    const memberType = ts.isTypeReferenceNode(node.type!)
+      ? node.type!.typeName.getText()
+      : node.type!.getText();
+
+    const memberTypeText = getTypeFromNamespace(memberType);
+    const fieldType = getFieldType(memberTypeText);
+
+    const { name, description, details } = parseJsDoc(node);
+
+    if (fieldType === 'unknown') {
+      const source = getLineAndColumnsNumber(node, sourceFile);
+
+      unknownFields.push({
+        parent,
+        name: fieldName,
+        type: memberTypeText,
+        source: `${relativePath}:${source.start.line}:${source.start.character}`,
+      });
+
+      return null;
+    }
+
+    // @ts-expect-error TS is being too strict here.
+    const field: SchemaField = {
+      id: generateFieldId(fieldType),
+      type: fieldType,
+      slug: fieldName,
+      name: name || fieldName.charAt(0).toUpperCase() + fieldName.slice(1),
+      unique: false,
+      required: !node.questionToken,
+    };
+
+    if (description) {
+      field.description = description;
+    }
+
+    if (field.type === 'string') {
+      field.displayAs = 'single-line';
+    }
+
+    if (field.type === 'reference') {
+      let schema: string | null = null;
+      schema = checkSchemaInclusion(node, parent);
+
+      if (schema) {
+        field.schema = schema;
+      }
+    }
+
+    // This feature is not yet official.
+    if (REGISTER_TSDOC_TAGS && Object.keys(details).length > 0) {
+      // @ts-expect-error This property is not yet defined in the schema field, but it soon will be.
+      field.details = details;
+    }
+
+    // This feature is not yet official.
+    if (
+      REGISTER_JSON_FIELD_STRUCTURE &&
+      field.type === 'json' &&
+      node.type &&
+      ts.isTypeReferenceNode(node.type) &&
+      node.type.typeArguments
+    ) {
+      // @ts-expect-error This property is not yet defined in the schema field, but it soon will be.
+      field.meta = parseTypeNode(node.type.typeArguments[0]);
+    }
+
+    return field;
+  }
+
   function parseTypeAlias(typeName: string, propertyName: string): any {
-    const result: Partial<Omit<Schema, 'fields'>> & { fields: NonNullable<Schema['fields']> } = {
+    const result: Partial<Schema> & { fields: NonNullable<Schema['fields']> } = {
       name: convertToReadableText(typeName),
       slug: propertyName,
       pluralName: '',
@@ -360,16 +483,15 @@ export async function parseSchemaDefinitionFile(
       fields: [],
     };
 
-    Object.keys(schemaProperties).forEach((schemaPropertyName) => {
-      const schemaPropertyType = schemaProperties[schemaPropertyName];
-      console.log({ schemaPropertyName, schemaPropertyType });
+    Object.keys(registeredSchemas).forEach((schemaSlug) => {
+      const schemaType = registeredSchemas[schemaSlug];
 
-      const { resolvedTypeName, typeArguments } = resolveTypeAlias(schemaPropertyType);
+      const { resolvedTypeName, typeArguments } = resolveTypeAlias(schemaType);
       const firstTypeArgument = typeArguments[0]?.getText();
 
       if (resolvedTypeName === schemaRecordsAlias && typeName === firstTypeArgument) {
-        result.pluralName = convertToReadableText(schemaPropertyType);
-        result.pluralSlug = schemaPropertyName;
+        result.pluralName = convertToReadableText(schemaType);
+        result.pluralSlug = schemaSlug;
       }
     });
 
@@ -377,79 +499,15 @@ export async function parseSchemaDefinitionFile(
       if (ts.isTypeAliasDeclaration(node) && node.name.text === typeName) {
         if (ts.isTypeReferenceNode(node.type) && node.type.typeArguments) {
           const typeLiteral = node.type.typeArguments[0];
+
           if (ts.isTypeLiteralNode(typeLiteral)) {
             typeLiteral.members.forEach((member) => {
               if (ts.isPropertySignature(member)) {
-                const fieldName = member.name.getText();
+                const parsedField = parseFieldDefinition(member, typeName);
 
-                const memberType = ts.isTypeReferenceNode(member.type!)
-                  ? member.type!.typeName.getText()
-                  : member.type!.getText();
-
-                const typeArguments =
-                  ts.isTypeReferenceNode(member.type!) && member.type!.typeArguments
-                    ? member.type!.typeArguments.map((arg) => arg.getText())
-                    : [];
-                console.log('memberType', memberType);
-
-                const memberTypeText = getTypeFromNamespace(memberType);
-                console.log({ fieldName, memberTypeText });
-                const fieldType = getFieldType(memberTypeText);
-
-                const { name, description, details } = parseJsDoc(member);
-
-                let schema: string | null = null;
-                if (fieldType === 'reference') {
-                  schema = checkSchemaInclusion(member, typeName);
+                if (parsedField) {
+                  result.fields.push(parsedField);
                 }
-                if (fieldType === 'unknown') {
-                  const source = getLineAndColumnsNumber(member);
-
-                  unknownFields.push({
-                    parent: typeName,
-                    name: fieldName,
-                    type: memberTypeText,
-                    source: `${relativePath}:${source.start.line}:${source.start.character}`,
-                  });
-                }
-
-                const field: Record<string, unknown> = {
-                  id: generateFieldId(fieldType),
-                  type: fieldType,
-                  slug: fieldName,
-                  name: name || fieldName.charAt(0).toUpperCase() + fieldName.slice(1),
-                  unique: false,
-                  required: !member.questionToken,
-                };
-
-                if (description) {
-                  field.description = description;
-                }
-
-                if (fieldType === 'string') {
-                  field.displayAs = 'single-line';
-                }
-
-                if (Object.keys(details).length > 0) {
-                  field.details = details;
-                }
-
-                console.log({ fieldType, memberTypeText, member, field });
-
-                if (
-                  fieldType === 'json' &&
-                  member.type &&
-                  ts.isTypeReferenceNode(member.type) &&
-                  member.type.typeArguments
-                ) {
-                  field.meta = parseTypeNode(member.type.typeArguments[0]);
-                }
-
-                if (schema) {
-                  field.schema = schema;
-                }
-
-                result.fields.push(field as (typeof result.fields)[0]);
               }
             });
           }
@@ -462,14 +520,7 @@ export async function parseSchemaDefinitionFile(
     ts.forEachChild(sourceFile, typeAliasVisitor);
 
     if (!result.pluralName && result.fields.length) {
-      const pluralTypeName = pluralize(typeName);
-      onError(
-        `The schema \`${typeName}\` does not have a plural slug and name defined.\n\n` +
-          `Please define them in your schema definition file and include them in the \`Schemas\` interface:\n\n` +
-          `import type * as Schema from 'ronin/schema';\n\n` +
-          `type ${pluralTypeName} = Schema.${schemaRecordsAlias}<${typeName}>;\n\n` +
-          `interface Schemas {\n  ${propertyName}: ${typeName};\n  ${pluralize(result.slug as string)}: ${pluralTypeName};\n}`,
-      );
+      onError?.(createMissingPluralError(typeName, propertyName, result.slug as string, schemaRecordsAlias));
     }
 
     return result.fields.length ? result : null;
@@ -484,33 +535,12 @@ export async function parseSchemaDefinitionFile(
   visit(sourceFile);
 
   if (missingSchemas.length > 0) {
-    const errorMessage =
-      `The following schemas were used as a reference but weren't included in ` +
-      `the \`Schemas\` interface:\n\n` +
-      `${missingSchemas
-        .map(({ name, parent, source }) => `  - \`${name}\` in \`${parent}\` (${source})`)
-        .join('\n')}\n\n` +
-      `Please include them in the \`Schemas\` interface or remove their references.`;
-
-    onError(errorMessage);
+    onError?.(createMissingSchemaError(missingSchemas));
   }
 
   if (unknownFields.length > 0) {
-    const errorMessage =
-      'The type of the following fields could not be determined:\n\n' +
-      Array.from(unknownFields)
-        .map(
-          ({ name, parent, type, source }) => `  - \`${parent}.${name}\` is typed as \`${type}\` (${source})`,
-        )
-        .join('\n') +
-      '\n\nPlease make sure that the field is typed as any of the available field types:\n\n' +
-      PRIMITIVE_FIELD_TYPES.map((type) => `  - \`${type}\``).join('\n') +
-      '\n' +
-      FIELD_TYPES.map((type) => `  - \`Schema.${type}\``).join('\n') +
-      '\n  - or a reference to another schema.';
-
-    onError(errorMessage);
+    onError?.(createUnknownFieldError(unknownFields));
   }
 
-  return results;
+  return schemas;
 }

--- a/src/bin/parser/index.ts
+++ b/src/bin/parser/index.ts
@@ -360,14 +360,6 @@ export function parseSchemaDefinitions(
         type: getFieldType(typeName),
         ...(typeNode.typeArguments ? { meta: parseTypeNode(typeNode.typeArguments[0]) } : {}),
       };
-
-      // TODO: This will be fixed soon.
-      // eslint-disable-next-line no-dupe-else-if
-    } else if (ts.isTypeLiteralNode(typeNode)) {
-      return {
-        type: 'object',
-        children: parseTypeNode(typeNode),
-      };
     } else if (ts.isLiteralTypeNode(typeNode)) {
       return {
         type: 'enum',

--- a/src/bin/parser/index.ts
+++ b/src/bin/parser/index.ts
@@ -13,6 +13,7 @@ import {
   getLineAndColumnsNumber,
   parseJsDoc,
 } from '@/src/bin/parser/utils';
+import { IS_TEST } from '@/src/bin/utils/env';
 import { exists } from '@/src/bin/utils/file';
 import type { Schema, SchemaField } from '@/src/types/schema';
 
@@ -24,8 +25,10 @@ export type ParsedSchema = Omit<
 };
 
 // Experimental features.
-const REGISTER_TSDOC_TAGS = process.env.NODE_ENV === 'test';
-const REGISTER_JSON_FIELD_STRUCTURE = process.env.NODE_ENV === 'test';
+const EXPERIMENTAL = {
+  TSDOC_TAGS: IS_TEST,
+  JSON_FIELD_STRUCTURE: IS_TEST,
+};
 
 const RONIN_MODULE = 'ronin';
 // The name of the interface to define the schemas in
@@ -34,7 +37,7 @@ const SCHEMAS_INTERFACE = 'Schemas';
 /**
  * Parses the schema definition file and returns an array of `Schema` objects.
  *
- * @param filePath The path to the schema definition file.
+ * @param filePath - The path to the schema definition file.
  *
  * @returns A promise that resolves to an array of `Schema` objects.
  */
@@ -60,9 +63,9 @@ export async function parseSchemaDefinitionFile(
  * Parses the schema definitions from the file content and returns an array
  * of `Schema` objects.
  *
- * @param content The content of the schema definition file.
- * @param relativePath The relative path to the schema definition file.
- * @param onError A callback function that is called when an error occurs.
+ * @param content - The content of the schema definition file.
+ * @param relativePath - The relative path to the schema definition file.
+ * @param onError - A callback function that is called when an error occurs.
  *
  * @returns An array of `Schema` objects.
  */
@@ -155,7 +158,7 @@ export function parseSchemaDefinitions(
       const namedBindings = node.importClause.namedBindings;
 
       if (ts.isNamedImports(namedBindings)) {
-        namedBindings.elements.forEach((element) => {
+        for (const element of namedBindings.elements) {
           const importedName = element.name.text;
           const originalName = element.propertyName ? element.propertyName.text : importedName;
           typeMapping[importedName] = originalName;
@@ -165,7 +168,7 @@ export function parseSchemaDefinitions(
           } else if (originalName === 'Records') {
             schemaRecordsAlias = importedName;
           }
-        });
+        }
       } else if (ts.isNamespaceImport(namedBindings)) {
         namespaces[namedBindings.name.text] = node.moduleSpecifier.getText().replace(/['"]/g, '');
       }
@@ -185,11 +188,11 @@ export function parseSchemaDefinitions(
   function visitRoninModuleDeclaration(node: ts.Node) {
     if (ts.isModuleDeclaration(node) && node.name.text === RONIN_MODULE) {
       if (node.body && ts.isModuleBlock(node.body)) {
-        node.body.statements.forEach((statement) => {
+        for (const statement of node.body.statements) {
           if (ts.isInterfaceDeclaration(statement) && statement.name.text === SCHEMAS_INTERFACE) {
             visitInterface(statement);
           }
-        });
+        }
       }
     }
   }
@@ -200,7 +203,7 @@ export function parseSchemaDefinitions(
    * @param node - The TypeScript interface declaration node to visit.
    */
   function visitInterface(node: ts.InterfaceDeclaration) {
-    node.members.forEach((member) => {
+    for (const member of node.members) {
       if (ts.isPropertySignature(member)) {
         const propertyName = member.name.getText();
         const typeName =
@@ -210,16 +213,16 @@ export function parseSchemaDefinitions(
           registeredSchemas[propertyName] = typeName;
         }
       }
-    });
+    }
 
-    Object.keys(registeredSchemas).forEach((propertyName) => {
+    for (const propertyName of Object.keys(registeredSchemas)) {
       const typeAlias = registeredSchemas[propertyName];
       const parsedType = parseSchemaProperty(propertyName, typeAlias);
 
       if (parsedType) {
         schemas.push(parsedType);
       }
-    });
+    }
   }
 
   /**
@@ -412,8 +415,8 @@ export function parseSchemaDefinitions(
   /**
    * Parses a schema field definitions
    *
-   * @param node The schema property node to parse.
-   * @param parent The name of the type that contains (schema) this property.
+   * @param node - The schema property node to parse.
+   * @param parent - The name of the type that contains (schema) this property.
    *
    * @returns The parsed schema field or `null` if the field type cannot be
    * determined.
@@ -471,14 +474,14 @@ export function parseSchemaDefinitions(
     }
 
     // This feature is not yet official.
-    if (REGISTER_TSDOC_TAGS && Object.keys(details).length > 0) {
+    if (EXPERIMENTAL.TSDOC_TAGS && Object.keys(details).length > 0) {
       // @ts-expect-error This property is not yet defined in the schema field, but it soon will be.
       field.details = details;
     }
 
     // This feature is not yet official.
     if (
-      REGISTER_JSON_FIELD_STRUCTURE &&
+      EXPERIMENTAL.JSON_FIELD_STRUCTURE &&
       field.type === 'json' &&
       node.type &&
       ts.isTypeReferenceNode(node.type) &&
@@ -494,8 +497,8 @@ export function parseSchemaDefinitions(
   /**
    * Used for parsing the properties of the `Schemas` interface.
    *
-   * @param typeAlias
-   * @param propertyName
+   * @param typeAlias - Schema type alias.
+   * @param propertyName - Schema property name (i.e. schema slug).
    *
    * @returns The parsed schema or `null` if no fields were found for the schema.
    */
@@ -508,7 +511,7 @@ export function parseSchemaDefinitions(
       fields: [],
     };
 
-    Object.keys(registeredSchemas).forEach((schemaSlug) => {
+    for (const schemaSlug of Object.keys(registeredSchemas)) {
       const schemaType = registeredSchemas[schemaSlug];
 
       const { resolvedTypeName, typeArguments } = resolveTypeAlias(schemaType);
@@ -518,7 +521,7 @@ export function parseSchemaDefinitions(
         result.pluralName = convertToReadableText(schemaType);
         result.pluralSlug = schemaSlug;
       }
-    });
+    }
 
     function typeAliasVisitor(node: ts.Node) {
       if (ts.isTypeAliasDeclaration(node) && node.name.text === typeAlias) {
@@ -526,7 +529,7 @@ export function parseSchemaDefinitions(
           const typeLiteral = node.type.typeArguments[0];
 
           if (ts.isTypeLiteralNode(typeLiteral)) {
-            typeLiteral.members.forEach((member) => {
+            for (const member of typeLiteral.members) {
               if (ts.isPropertySignature(member)) {
                 const parsedField = parseFieldDefinition(member, typeAlias);
 
@@ -534,7 +537,7 @@ export function parseSchemaDefinitions(
                   result.fields.push(parsedField);
                 }
               }
-            });
+            }
           }
         }
       }

--- a/src/bin/parser/index.ts
+++ b/src/bin/parser/index.ts
@@ -321,10 +321,16 @@ export function parseSchemaDefinitions(
     if (ts.isTypeLiteralNode(typeNode)) {
       return typeNode.members.map((member) => {
         if (ts.isPropertySignature(member)) {
+          if (!member.type) {
+            throw new Error(
+              `Property signature \`${member.getText()}\` in ${typeNode.parent.getText()} is missing a type`,
+            );
+          }
+
           const fieldName = member.name.getText();
           const isRequired = !member.questionToken;
 
-          let fieldType = getFieldType(member.type!.getText());
+          let fieldType = getFieldType(member.type.getText());
 
           const parsedField: ParsedTypeArgument = {
             name: fieldName,
@@ -332,30 +338,30 @@ export function parseSchemaDefinitions(
             required: isRequired,
           };
 
-          if (ts.isArrayTypeNode(member.type!)) {
+          if (ts.isArrayTypeNode(member.type)) {
             parsedField.type = 'array';
-            parsedField.children = parseTypeNode(member.type!.elementType);
-          } else if (ts.isUnionTypeNode(member.type!)) {
+            parsedField.children = parseTypeNode(member.type.elementType);
+          } else if (ts.isUnionTypeNode(member.type)) {
             parsedField.type = 'enum';
-            parsedField.value = member.type!.types.map((t) => t.getText().replace(/"/g, ''));
-          } else if (ts.isTypeReferenceNode(member.type!)) {
-            const typeName = member.type!.typeName.getText();
+            parsedField.value = member.type.types.map((t) => t.getText().replace(/"/g, ''));
+          } else if (ts.isTypeReferenceNode(member.type)) {
+            const typeName = member.type.typeName.getText();
             if (typeName === 'Array') {
               parsedField.type = 'array';
-              parsedField.children = parseTypeNode(member.type!.typeArguments![0]);
+              parsedField.children = parseTypeNode(member.type.typeArguments![0]);
             } else {
               fieldType = getFieldType(typeName);
               parsedField.type = fieldType;
-              if (member.type!.typeArguments) {
-                parsedField.meta = parseTypeNode(member.type!.typeArguments[0]);
+              if (member.type.typeArguments) {
+                parsedField.meta = parseTypeNode(member.type.typeArguments[0]);
               }
             }
-          } else if (ts.isTypeLiteralNode(member.type!)) {
+          } else if (ts.isTypeLiteralNode(member.type)) {
             parsedField.type = 'object';
-            parsedField.children = parseTypeNode(member.type!);
-          } else if (ts.isLiteralTypeNode(member.type!)) {
+            parsedField.children = parseTypeNode(member.type);
+          } else if (ts.isLiteralTypeNode(member.type)) {
             parsedField.type = 'enum';
-            parsedField.value = [member.type!.literal.getText().replace(/"/g, '')];
+            parsedField.value = [member.type.literal.getText().replace(/"/g, '')];
           } else {
             parsedField.type = fieldType;
           }
@@ -403,7 +409,11 @@ export function parseSchemaDefinitions(
    * @returns The name of the schema property if found, otherwise null.
    */
   function checkSchemaInclusion(node: ts.PropertySignature, parent: string): string | null {
-    const typeName = node.type!.getText();
+    // `node.type` cannot be `undefined` here because the function is only called
+    // when `node.type` is equal to a defined value.
+    const nodeType = node.type!;
+    const typeName = nodeType.getText();
+
     const schemaSlug = Object.keys(registeredSchemas).find((key) => registeredSchemas[key] === typeName);
 
     if (schemaSlug) {
@@ -441,11 +451,13 @@ export function parseSchemaDefinitions(
    * determined.
    */
   function parseFieldDefinition(node: ts.PropertySignature, parent: string): SchemaField | null {
+    if (!node.type) {
+      throw new Error(`Property signature \`${node.getText()}\` in ${parent} is missing a type`);
+    }
+
     const fieldName = node.name.getText();
 
-    const memberType = ts.isTypeReferenceNode(node.type!)
-      ? node.type!.typeName.getText()
-      : node.type!.getText();
+    const memberType = ts.isTypeReferenceNode(node.type) ? node.type.typeName.getText() : node.type.getText();
 
     const memberTypeText = getTypeFromNamespace(memberType);
     const fieldType = getFieldType(memberTypeText);

--- a/src/bin/parser/utils.ts
+++ b/src/bin/parser/utils.ts
@@ -8,7 +8,8 @@ import { generateUniqueId } from '@/src/utils/id';
  * @param type The type of the field.
  */
 export const generateFieldId = (type: string): string => {
-  return `${type}-${generateUniqueId()}`;
+  const id = process.env.NODE_ENV === 'test' ? '0' : generateUniqueId();
+  return `${type}-${id}`;
 };
 
 /**

--- a/src/bin/parser/utils.ts
+++ b/src/bin/parser/utils.ts
@@ -1,5 +1,6 @@
 import ts from 'typescript';
 
+import { IS_TEST } from '@/src/bin/utils/env';
 import { generateUniqueId } from '@/src/utils/id';
 
 /**
@@ -9,7 +10,7 @@ import { generateUniqueId } from '@/src/utils/id';
  */
 export const generateFieldId = (type: string): string => {
   // We use a fixed ID for tests to make it easier to use snapshots.
-  const id = process.env.NODE_ENV === 'test' ? '0' : generateUniqueId();
+  const id = IS_TEST ? '0' : generateUniqueId();
 
   return `${type}-${id}`;
 };

--- a/src/bin/parser/utils.ts
+++ b/src/bin/parser/utils.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 
-import { IS_TEST } from '@/src/bin/utils/env';
+import { isTest } from '@/src/bin/utils/env';
 import { generateUniqueId } from '@/src/utils/id';
 
 /**
@@ -10,15 +10,15 @@ import { generateUniqueId } from '@/src/utils/id';
  */
 export const generateFieldId = (type: string): string => {
   // We use a fixed ID for tests to make it easier to use snapshots.
-  const id = IS_TEST ? '0' : generateUniqueId();
+  const id = isTest() ? '0' : generateUniqueId();
 
   return `${type}-${id}`;
 };
 
 /**
  * Converts a given string into a readable text format.
- * Inserts spaces before each uppercase letter (except the first letter)
- * and capitalizes the first letter of each word.
+ * Inserts spaces before each uppercase letter (except the first letter),
+ * and between letters and digits, and capitalizes the first letter of each word.
  *
  * @param str - The string to be converted.
  * @returns - The formatted readable text or null if input is invalid.
@@ -27,10 +27,14 @@ export function convertToReadableText(str: null): null;
 export function convertToReadableText(str: undefined): null;
 export function convertToReadableText(str: string): string;
 export function convertToReadableText(str: undefined | null | string): string | null {
+  if (str === '') return '';
   if (!str || typeof str !== 'string') return null;
 
   // Insert spaces before each uppercase letter (except the first letter).
-  const spacedStr = str.replace(/([a-z])([A-Z])/g, '$1 $2');
+  let spacedStr = str.replace(/([a-z])([A-Z])/g, '$1 $2');
+
+  // Insert spaces between letters and digits.
+  spacedStr = spacedStr.replace(/([a-zA-Z])(\d)/g, '$1 $2').replace(/(\d)([a-zA-Z])/g, '$1 $2');
 
   // Split the string into words.
   const words = spacedStr.split(' ');
@@ -41,7 +45,6 @@ export function convertToReadableText(str: undefined | null | string): string | 
   // Join the words back into a single string with spaces.
   return capitalizedWords.join(' ');
 }
-
 /**
  * Retrieves the line and column numbers for the start and end positions of
  * a given TypeScript node.

--- a/src/bin/parser/utils.ts
+++ b/src/bin/parser/utils.ts
@@ -8,7 +8,9 @@ import { generateUniqueId } from '@/src/utils/id';
  * @param type The type of the field.
  */
 export const generateFieldId = (type: string): string => {
+  // We use a fixed ID for tests to make it easier to use snapshots.
   const id = process.env.NODE_ENV === 'test' ? '0' : generateUniqueId();
+
   return `${type}-${id}`;
 };
 

--- a/src/bin/parser/utils.ts
+++ b/src/bin/parser/utils.ts
@@ -1,0 +1,111 @@
+import ts from 'typescript';
+
+import { generateUniqueId } from '@/src/utils/id';
+
+/**
+ * Generates a unique field ID.
+ *
+ * @param type The type of the field.
+ */
+export const generateFieldId = (type: string): string => {
+  return `${type}-${generateUniqueId()}`;
+};
+
+/**
+ * Converts a given string into a readable text format.
+ * Inserts spaces before each uppercase letter (except the first letter)
+ * and capitalizes the first letter of each word.
+ *
+ * @param str - The string to be converted.
+ * @returns - The formatted readable text or null if input is invalid.
+ */
+export function convertToReadableText(str: null): null;
+export function convertToReadableText(str: undefined): null;
+export function convertToReadableText(str: string): string;
+export function convertToReadableText(str: undefined | null | string): string | null {
+  if (!str || typeof str !== 'string') return null;
+
+  // Insert spaces before each uppercase letter (except the first letter).
+  const spacedStr = str.replace(/([a-z])([A-Z])/g, '$1 $2');
+
+  // Split the string into words.
+  const words = spacedStr.split(' ');
+
+  // Capitalize the first letter of each word.
+  const capitalizedWords = words.map((word) => word.charAt(0).toUpperCase() + word.slice(1));
+
+  // Join the words back into a single string with spaces.
+  return capitalizedWords.join(' ');
+}
+
+/**
+ * Retrieves the line and column numbers for the start and end positions of
+ * a given TypeScript node.
+ *
+ * @param node - The TypeScript node to get the line and column numbers for.
+ * @param sourceFile - The source file containing the node.
+ * @returns An object containing the start and end positions with line and column numbers.
+ */
+export function getLineAndColumnsNumber(
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+): { start: { line: number; character: number }; end: { line: number; character: number } } {
+  const { line: startLine, character: startCharacter } = sourceFile.getLineAndCharacterOfPosition(
+    node.getStart(),
+  );
+
+  const { line: endLine, character: endCharacter } = sourceFile.getLineAndCharacterOfPosition(node.getEnd());
+
+  return {
+    start: { line: startLine + 1, character: startCharacter + 1 },
+    end: { line: endLine + 1, character: endCharacter + 1 },
+  };
+}
+
+/**
+ * Parses JSDoc comments from a TypeScript node and extracts the name,
+ * description, and details.
+ *
+ * @param node - The TypeScript node to parse JSDoc comments from.
+ * @returns An object containing the name, description, and details extracted
+ * from the JSDoc comments.
+ */
+export function parseJsDoc(node: ts.Node): {
+  name: string;
+  description: string;
+  details: Record<string, string>;
+} {
+  let name = '';
+  let description = '';
+  const details: Record<string, string> = {};
+
+  const commentsAndTags = ts.getJSDocCommentsAndTags(node);
+
+  if (commentsAndTags.length > 0) {
+    const jsDoc = commentsAndTags[0];
+    const commentText = jsDoc.comment ? ts.getTextOfJSDocComment(jsDoc.comment) : undefined;
+
+    if (commentText) {
+      const lines = commentText
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line);
+      if (lines.length > 0) {
+        name = lines[0];
+        description = lines.slice(1).join(' ');
+      }
+    }
+
+    if ('tags' in jsDoc && jsDoc.tags) {
+      jsDoc.tags.forEach((tag) => {
+        const tagName = tag.tagName.getText();
+        const tagComment = ts.getTextOfJSDocComment(tag.comment);
+        if (tagComment) {
+          details[tagName] = tagComment;
+        }
+      });
+    }
+  }
+
+  return { name, description, details };
+}

--- a/src/bin/utils/env.ts
+++ b/src/bin/utils/env.ts
@@ -1,0 +1,1 @@
+export const IS_TEST = process.env.NODE_ENV === 'test';

--- a/src/bin/utils/env.ts
+++ b/src/bin/utils/env.ts
@@ -1,1 +1,1 @@
-export const IS_TEST = process.env.NODE_ENV === 'test';
+export const isTest = () => process.env.NODE_ENV === 'test';

--- a/src/bin/utils/file.ts
+++ b/src/bin/utils/file.ts
@@ -10,11 +10,9 @@ export const exists = async (file: string) => {
   try {
     await fs.access(path.join(process.cwd(), file));
   } catch (err) {
-    if ((err as { code: string }).code === 'ENOENT') {
-      return false;
-    } else {
-      throw err;
-    }
+    // TODO: Handle errors other than ENOENT. Currently, we're not doing this
+    // because we haven't found a way to realibly test and mock this use case.
+    return false;
   }
 
   return true;

--- a/src/bin/utils/schema.ts
+++ b/src/bin/utils/schema.ts
@@ -94,7 +94,9 @@ export async function parseSchemaDefinitionFile(
       case 'JSON':
         return 'json';
       default: {
-        const { resolvedTypeName } = resolveTypeAlias(originalType);
+        const { resolvedTypeName, namespace, typeArguments } = resolveTypeAlias(originalType);
+
+        console.log({ resolvedTypeName, namespace, typeArguments });
 
         if (resolvedTypeName === schemaRecordAlias) {
           return 'reference';
@@ -200,6 +202,8 @@ export async function parseSchemaDefinitionFile(
     typeArguments: ts.TypeNode[];
     namespace: string | null;
   } {
+    console.log({ typeName });
+
     let resolvedTypeName = typeName;
     let typeArguments: ts.TypeNode[] = [];
     let namespace: string | null = null;
@@ -223,12 +227,90 @@ export async function parseSchemaDefinitionFile(
           }
         }
       }
+
       ts.forEachChild(node, typeAliasVisitor);
     }
 
     ts.forEachChild(sourceFile, typeAliasVisitor);
 
     return { resolvedTypeName, typeArguments, namespace };
+  }
+
+  function parseTypeNode(typeNode: ts.TypeNode): any {
+    if (ts.isTypeLiteralNode(typeNode)) {
+      return typeNode.members.map((member) => {
+        if (ts.isPropertySignature(member)) {
+          const fieldName = member.name.getText();
+          const isRequired = !member.questionToken;
+          let fieldType = getFieldType(member.type!.getText());
+
+          let parsedField: any = {
+            name: fieldName,
+            type: fieldType,
+            required: isRequired,
+          };
+
+          if (ts.isArrayTypeNode(member.type!)) {
+            parsedField.type = 'array';
+            parsedField.children = parseTypeNode(member.type!.elementType);
+          } else if (ts.isUnionTypeNode(member.type!)) {
+            parsedField.type = 'enum';
+            parsedField.value = member.type!.types.map((t) => t.getText().replace(/"/g, ''));
+          } else if (ts.isTypeReferenceNode(member.type!)) {
+            const typeName = member.type!.typeName.getText();
+            if (typeName === 'Array') {
+              parsedField.type = 'array';
+              parsedField.children = parseTypeNode(member.type!.typeArguments![0]);
+            } else {
+              fieldType = getFieldType(typeName);
+              parsedField.type = fieldType;
+              if (member.type!.typeArguments) {
+                parsedField.meta = parseTypeNode(member.type!.typeArguments[0]);
+              }
+            }
+          } else if (ts.isTypeLiteralNode(member.type!)) {
+            parsedField.type = 'object';
+            parsedField.children = parseTypeNode(member.type!);
+          } else if (ts.isLiteralTypeNode(member.type!)) {
+            parsedField.type = 'enum';
+            parsedField.value = [member.type!.literal.getText().replace(/"/g, '')];
+          } else {
+            parsedField.type = fieldType;
+          }
+
+          return parsedField;
+        }
+      });
+    } else if (ts.isUnionTypeNode(typeNode)) {
+      return {
+        type: 'enum',
+        value: typeNode.types.map((t) => t.getText().replace(/"/g, '')),
+      };
+    } else if (ts.isArrayTypeNode(typeNode)) {
+      return {
+        type: 'array',
+        children: parseTypeNode(typeNode.elementType),
+      };
+    } else if (ts.isTypeReferenceNode(typeNode)) {
+      const typeName = typeNode.typeName.getText();
+      return {
+        name: typeName,
+        type: getFieldType(typeName),
+        ...(typeNode.typeArguments ? { meta: parseTypeNode(typeNode.typeArguments[0]) } : {}),
+      };
+    } else if (ts.isTypeLiteralNode(typeNode)) {
+      return {
+        type: 'object',
+        children: parseTypeNode(typeNode),
+      };
+    } else if (ts.isLiteralTypeNode(typeNode)) {
+      return {
+        type: 'enum',
+        value: [typeNode.literal.getText().replace(/"/g, '')],
+      };
+    } else {
+      return { type: typeNode.getText() };
+    }
   }
 
   function getLineAndColumnsNumber(node: ts.Node) {
@@ -280,6 +362,8 @@ export async function parseSchemaDefinitionFile(
 
     Object.keys(schemaProperties).forEach((schemaPropertyName) => {
       const schemaPropertyType = schemaProperties[schemaPropertyName];
+      console.log({ schemaPropertyName, schemaPropertyType });
+
       const { resolvedTypeName, typeArguments } = resolveTypeAlias(schemaPropertyType);
       const firstTypeArgument = typeArguments[0]?.getText();
 
@@ -297,7 +381,19 @@ export async function parseSchemaDefinitionFile(
             typeLiteral.members.forEach((member) => {
               if (ts.isPropertySignature(member)) {
                 const fieldName = member.name.getText();
-                const memberTypeText = getTypeFromNamespace(member.type!.getText());
+
+                const memberType = ts.isTypeReferenceNode(member.type!)
+                  ? member.type!.typeName.getText()
+                  : member.type!.getText();
+
+                const typeArguments =
+                  ts.isTypeReferenceNode(member.type!) && member.type!.typeArguments
+                    ? member.type!.typeArguments.map((arg) => arg.getText())
+                    : [];
+                console.log('memberType', memberType);
+
+                const memberTypeText = getTypeFromNamespace(memberType);
+                console.log({ fieldName, memberTypeText });
                 const fieldType = getFieldType(memberTypeText);
 
                 const { name, description, details } = parseJsDoc(member);
@@ -336,6 +432,17 @@ export async function parseSchemaDefinitionFile(
 
                 if (Object.keys(details).length > 0) {
                   field.details = details;
+                }
+
+                console.log({ fieldType, memberTypeText, member, field });
+
+                if (
+                  fieldType === 'json' &&
+                  member.type &&
+                  ts.isTypeReferenceNode(member.type) &&
+                  member.type.typeArguments
+                ) {
+                  field.meta = parseTypeNode(member.type.typeArguments[0]);
                 }
 
                 if (schema) {

--- a/src/bin/utils/sync.ts
+++ b/src/bin/utils/sync.ts
@@ -1,6 +1,6 @@
 import { confirm } from '@inquirer/prompts';
 
-import { generateFieldId } from '@/src/bin/utils/schema';
+import { generateFieldId } from '@/src/bin/parser/utils';
 import type { Schema } from '@/src/types/schema';
 
 /**

--- a/src/bin/utils/sync.ts
+++ b/src/bin/utils/sync.ts
@@ -1,5 +1,7 @@
 import { confirm } from '@inquirer/prompts';
+import type { Ora } from 'ora';
 
+import type { ParsedSchema } from '@/src/bin/parser';
 import { generateFieldId } from '@/src/bin/parser/utils';
 import type { Schema } from '@/src/types/schema';
 
@@ -89,7 +91,10 @@ export const getSchemas = async (token: string, space: string): Promise<Schema[]
  *
  * @returns Updated local schema definitions.
  */
-export const replaceFieldIdsWithExisting = async (local: Schema[], remote: Schema[]): Promise<Schema[]> => {
+export const replaceFieldIdsWithExisting = async (
+  local: ParsedSchema[],
+  remote: Schema[],
+): Promise<ParsedSchema[]> => {
   return local.map((schema) => {
     const existingSchema = remote.find((s) => s.slug === schema.slug);
     if (!existingSchema) {
@@ -129,7 +134,7 @@ export const replaceFieldIdsWithExisting = async (local: Schema[], remote: Schem
  * @param remote Existing remote schema definitions.
  * @param spinner The spinner instance to log messages.
  */
-export const compareSchemas = async (local: Schema[], remote: Schema[], spinner: any) => {
+export const compareSchemas = async (local: ParsedSchema[], remote: Schema[], spinner: Ora) => {
   const fieldsWithDifferentTypes: string[] = [];
 
   local.forEach(({ slug: schemaSlug, fields }) => {

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,12 +1,12 @@
 import type { RONIN } from '@/src/types/codegen';
 
+type ValidJSON = string | number | boolean | null | ValidJSON[] | { [key: string]: ValidJSON };
+
 type Blob = RONIN.Blob;
-type Token = string;
-type RichText = string;
-type JSONField = JSON;
+type JSONField<T extends ValidJSON | undefined = undefined> = T extends undefined ? ValidJSON : T;
 
 type SchemaRecord<TSchema extends Record<string, any>> = Required<TSchema> & RONIN.RoninRecord;
 
 type SchemaRecords<TSchema extends SchemaRecord<TSchema>> = RONIN.RoninRecords<TSchema>;
 
-export type { SchemaRecord as Record, SchemaRecords as Records, Blob, Token, RichText, JSONField as JSON };
+export type { SchemaRecord as Record, SchemaRecords as Records, Blob, JSONField as JSON };

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -8,82 +8,17 @@ export type BasicSchemaField = {
   unique?: boolean | undefined;
 };
 
-export type StringSchemaField = {
-  id: string;
-  slug: string;
-  name: string;
-  description?: string | undefined;
-  required?: boolean | undefined;
-  unique?: boolean | undefined;
+export type StringSchemaField = Omit<BasicSchemaField, 'type'> & {
   type: 'string';
   displayAs?: 'single-line' | 'multi-line' | 'secret';
 };
 
-export type ListSchemaField = {
-  id: string;
-  slug: string;
-  name: string;
-  description?: string | undefined;
-  required?: boolean | undefined;
-  unique?: boolean | undefined;
+export type ListSchemaField = Omit<BasicSchemaField, 'type'> & {
   type: 'list';
-  shape: (
-    | {
-        id: string;
-        slug: string;
-        name: string;
-        description?: string | undefined;
-        type: 'group' | 'date' | 'blob' | 'boolean' | 'number';
-        required?: boolean | undefined;
-        unique?: boolean | undefined;
-      }
-    | {
-        id: string;
-        slug: string;
-        name: string;
-        description?: string | undefined;
-        required?: boolean | undefined;
-        unique?: boolean | undefined;
-        type: 'string';
-        displayAs?: 'single-line' | 'multi-line' | 'secret';
-      }
-    | {
-        id: string;
-        slug: string;
-        name: string;
-        description?: string | undefined;
-        required?: boolean | undefined;
-        unique?: boolean | undefined;
-        type: 'reference';
-        schema: string | null;
-        space?: string | undefined;
-        action?:
-          | {
-              onDelete: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
-              onUpdate: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
-            }
-          | undefined;
-      }
-    | {
-        id: string;
-        slug: string;
-        name: string;
-        description?: string | undefined;
-        required?: boolean | undefined;
-        unique?: boolean | undefined;
-        type: 'json';
-        displayAs?: 'rich-text' | undefined;
-      }
-  )[];
+  shape: (BasicSchemaField | StringSchemaField | ReferenceSchemaField | JSONSchemaField)[];
 };
 
-export type ReferenceSchemaField = {
-  id: string;
-  slug: string;
-  name: string;
-  description?: string | undefined;
-  required?: boolean | undefined;
-  unique?: boolean | undefined;
+export type ReferenceSchemaField = Omit<BasicSchemaField, 'type'> & {
   type: 'reference';
   schema: string | null;
   space?: string | undefined;
@@ -95,13 +30,7 @@ export type ReferenceSchemaField = {
     | undefined;
 };
 
-export type JSONSchemaField = {
-  id: string;
-  slug: string;
-  name: string;
-  description?: string | undefined;
-  required?: boolean | undefined;
-  unique?: boolean | undefined;
+export type JSONSchemaField = Omit<BasicSchemaField, 'type'> & {
   type: 'json';
   displayAs?: 'rich-text' | undefined;
 };

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,113 +1,122 @@
+export type BasicSchemaField = {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | undefined;
+  type: 'group' | 'date' | 'blob' | 'boolean' | 'number';
+  required?: boolean | undefined;
+  unique?: boolean | undefined;
+};
+
+export type StringSchemaField = {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | undefined;
+  required?: boolean | undefined;
+  unique?: boolean | undefined;
+  type: 'string';
+  displayAs?: 'single-line' | 'multi-line' | 'secret';
+};
+
+export type ListSchemaField = {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | undefined;
+  required?: boolean | undefined;
+  unique?: boolean | undefined;
+  type: 'list';
+  shape: (
+    | {
+        id: string;
+        slug: string;
+        name: string;
+        description?: string | undefined;
+        type: 'group' | 'date' | 'blob' | 'boolean' | 'number';
+        required?: boolean | undefined;
+        unique?: boolean | undefined;
+      }
+    | {
+        id: string;
+        slug: string;
+        name: string;
+        description?: string | undefined;
+        required?: boolean | undefined;
+        unique?: boolean | undefined;
+        type: 'string';
+        displayAs?: 'single-line' | 'multi-line' | 'secret';
+      }
+    | {
+        id: string;
+        slug: string;
+        name: string;
+        description?: string | undefined;
+        required?: boolean | undefined;
+        unique?: boolean | undefined;
+        type: 'reference';
+        schema: string | null;
+        space?: string | undefined;
+        action?:
+          | {
+              onDelete: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
+              onUpdate: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
+            }
+          | undefined;
+      }
+    | {
+        id: string;
+        slug: string;
+        name: string;
+        description?: string | undefined;
+        required?: boolean | undefined;
+        unique?: boolean | undefined;
+        type: 'json';
+        displayAs?: 'rich-text' | undefined;
+      }
+  )[];
+};
+
+export type ReferenceSchemaField = {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | undefined;
+  required?: boolean | undefined;
+  unique?: boolean | undefined;
+  type: 'reference';
+  schema: string | null;
+  space?: string | undefined;
+  action?:
+    | {
+        onDelete: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
+        onUpdate: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
+      }
+    | undefined;
+};
+
+export type JSONSchemaField = {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | undefined;
+  required?: boolean | undefined;
+  unique?: boolean | undefined;
+  type: 'json';
+  displayAs?: 'rich-text' | undefined;
+};
+
+export type SchemaField =
+  | BasicSchemaField
+  | StringSchemaField
+  | ListSchemaField
+  | ReferenceSchemaField
+  | JSONSchemaField;
+
 export type Schema = {
   id: string;
   summary: string;
-  fields:
-    | (
-        | {
-            id: string;
-            slug: string;
-            name: string;
-            description?: string | undefined;
-            type: 'group' | 'date' | 'blob' | 'boolean' | 'number';
-            required?: boolean | undefined;
-            unique?: boolean | undefined;
-          }
-        | {
-            id: string;
-            slug: string;
-            name: string;
-            description?: string | undefined;
-            required?: boolean | undefined;
-            unique?: boolean | undefined;
-            type: 'string';
-            displayAs?: 'single-line' | 'multi-line' | 'secret';
-          }
-        | {
-            id: string;
-            slug: string;
-            name: string;
-            description?: string | undefined;
-            required?: boolean | undefined;
-            unique?: boolean | undefined;
-            type: 'list';
-            shape: (
-              | {
-                  id: string;
-                  slug: string;
-                  name: string;
-                  description?: string | undefined;
-                  type: 'group' | 'date' | 'blob' | 'boolean' | 'number';
-                  required?: boolean | undefined;
-                  unique?: boolean | undefined;
-                }
-              | {
-                  id: string;
-                  slug: string;
-                  name: string;
-                  description?: string | undefined;
-                  required?: boolean | undefined;
-                  unique?: boolean | undefined;
-                  type: 'string';
-                  displayAs?: 'single-line' | 'multi-line' | 'secret';
-                }
-              | {
-                  id: string;
-                  slug: string;
-                  name: string;
-                  description?: string | undefined;
-                  required?: boolean | undefined;
-                  unique?: boolean | undefined;
-                  type: 'reference';
-                  schema: string | null;
-                  space?: string | undefined;
-                  action?:
-                    | {
-                        onDelete: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
-                        onUpdate: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
-                      }
-                    | undefined;
-                }
-              | {
-                  id: string;
-                  slug: string;
-                  name: string;
-                  description?: string | undefined;
-                  required?: boolean | undefined;
-                  unique?: boolean | undefined;
-                  type: 'json';
-                  displayAs?: 'rich-text' | undefined;
-                }
-            )[];
-          }
-        | {
-            id: string;
-            slug: string;
-            name: string;
-            description?: string | undefined;
-            required?: boolean | undefined;
-            unique?: boolean | undefined;
-            type: 'reference';
-            schema: string | null;
-            space?: string | undefined;
-            action?:
-              | {
-                  onDelete: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
-                  onUpdate: ('cascade' | 'clear' | 'restrict' | 'reset') | null;
-                }
-              | undefined;
-          }
-        | {
-            id: string;
-            slug: string;
-            name: string;
-            description?: string | undefined;
-            required?: boolean | undefined;
-            unique?: boolean | undefined;
-            type: 'json';
-            displayAs?: 'rich-text' | undefined;
-          }
-      )[]
-    | null;
+  fields: SchemaField[] | null;
   identifiers: {
     title: string | null;
     slug: string | null;

--- a/tests/unit/__snapshots__/parser.test.ts.snap
+++ b/tests/unit/__snapshots__/parser.test.ts.snap
@@ -39,6 +39,8 @@ Please make sure that the field is typed as any of the available field types:
   - or a reference to another schema."
 `;
 
+exports[`Schema parser throw error schema field does not have a type 1`] = `"Property signature \`session\` in Account is missing a type"`;
+
 exports[`Schema parser schema with basic field types 1`] = `
 [
   {
@@ -367,6 +369,14 @@ exports[`Schema parser schema with generic field types 1`] = `
 ]
 `;
 
+exports[`Schema parser schema with unsupported property type in generic field types 1`] = `
+"Unsupported property type \`name(): void;\` in Schema.JSON<{ 
+                name(): void; 
+            }>"
+`;
+
+exports[`Schema parser schema with undefined property type in generic field types 1`] = `"Property signature \`name\` in Schema.JSON<{ name }> is missing a type"`;
+
 exports[`Schema parser schema with TSDoc 1`] = `
 [
   {
@@ -513,9 +523,3 @@ exports[`Schema parser with aliased imports 1`] = `
 `;
 
 exports[`Schema parser schema definitions file 1`] = `Promise {}`;
-
-exports[`Schema parser schema with unsupported property type in generic field types 1`] = `
-"Unsupported property type \`name(): void;\` in Schema.JSON<{ 
-                name(): void; 
-            }>"
-`;

--- a/tests/unit/__snapshots__/parser.test.ts.snap
+++ b/tests/unit/__snapshots__/parser.test.ts.snap
@@ -1,44 +1,5 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Schema parser throw error when plural schema is missing 1`] = `
-"The schema \`Account\` does not have a plural slug and name defined.
-
-Please define them in your schema definition file and include them in the \`Schemas\` interface:
-
-import type * as Schema from 'ronin/schema';
-
-type Accounts = Schema.Records<Account>;
-
-interface Schemas {
-  account: Account;
-  accounts: Accounts;
-}"
-`;
-
-exports[`Schema parser throw error referenced schema is not registered 1`] = `
-"The following schemas were used as a reference but weren't included in the \`Schemas\` interface:
-
-  - \`Session\` in \`Account\` (schemas/index.ts:9:13)
-
-Please include them in the \`Schemas\` interface or remove their references."
-`;
-
-exports[`Schema parser throw error schema field type cannot be determined 1`] = `
-"The type of the following fields could not be determined:
-
-  - \`Account.session\` is typed as \`ThisIsNotAValidType\` (schemas/index.ts:5:13)
-
-Please make sure that the field is typed as any of the available field types:
-
-  - \`string\`
-  - \`number\`
-  - \`boolean\`
-  - \`Date\`
-  - \`Schema.Blob\`
-  - \`Schema.JSON\`
-  - or a reference to another schema."
-`;
-
 exports[`Schema parser schema with basic field types 1`] = `
 [
   {

--- a/tests/unit/__snapshots__/parser.test.ts.snap
+++ b/tests/unit/__snapshots__/parser.test.ts.snap
@@ -121,11 +121,41 @@ exports[`Schema parser schema with generic field types 1`] = `
       {
         "id": "json-0",
         "meta": {
-          "type": "[{ name: string }]",
+          "name": "Schema.Blob",
+          "type": "unknown",
         },
         "name": "Metadata1",
         "required": true,
         "slug": "metadata1",
+        "type": "json",
+        "unique": false,
+      },
+      {
+        "id": "json-0",
+        "meta": {
+          "type": "enum",
+          "value": [
+            "option-1",
+          ],
+        },
+        "name": "Metadata2",
+        "required": true,
+        "slug": "metadata2",
+        "type": "json",
+        "unique": false,
+      },
+      {
+        "id": "json-0",
+        "meta": {
+          "type": "enum",
+          "value": [
+            "option-1",
+            "option-2",
+          ],
+        },
+        "name": "Metadata3",
+        "required": true,
+        "slug": "metadata3",
         "type": "json",
         "unique": false,
       },
@@ -138,9 +168,56 @@ exports[`Schema parser schema with generic field types 1`] = `
             "type": "string",
           },
         ],
-        "name": "Metadata1",
+        "name": "Metadata4",
         "required": true,
-        "slug": "metadata1",
+        "slug": "metadata4",
+        "type": "json",
+        "unique": false,
+      },
+      {
+        "id": "json-0",
+        "meta": {
+          "children": [
+            {
+              "name": "name",
+              "required": true,
+              "type": "string",
+            },
+          ],
+          "type": "array",
+        },
+        "name": "Metadata5",
+        "required": true,
+        "slug": "metadata5",
+        "type": "json",
+        "unique": false,
+      },
+      {
+        "id": "json-0",
+        "meta": {
+          "type": "[{ name: string }]",
+        },
+        "name": "Metadata6",
+        "required": true,
+        "slug": "metadata6",
+        "type": "json",
+        "unique": false,
+      },
+      {
+        "id": "json-0",
+        "meta": [
+          {
+            "name": "constant",
+            "required": true,
+            "type": "enum",
+            "value": [
+              "ronin",
+            ],
+          },
+        ],
+        "name": "Metadata7",
+        "required": true,
+        "slug": "metadata7",
         "type": "json",
         "unique": false,
       },
@@ -160,6 +237,21 @@ exports[`Schema parser schema with generic field types 1`] = `
               "active",
               "inactive",
             ],
+          },
+          {
+            "meta": [
+              {
+                "name": "type",
+                "required": true,
+                "type": "enum",
+                "value": [
+                  "images",
+                ],
+              },
+            ],
+            "name": "avatar",
+            "required": true,
+            "type": "unknown",
           },
           {
             "children": [
@@ -196,6 +288,14 @@ exports[`Schema parser schema with generic field types 1`] = `
                 "type": "boolean",
               },
               {
+                "children": {
+                  "type": "string",
+                },
+                "name": "array",
+                "required": true,
+                "type": "array",
+              },
+              {
                 "children": [
                   {
                     "name": "createdAt",
@@ -213,9 +313,9 @@ exports[`Schema parser schema with generic field types 1`] = `
             "type": "object",
           },
         ],
-        "name": "Metadata2",
+        "name": "Metadata8",
         "required": true,
-        "slug": "metadata2",
+        "slug": "metadata8",
         "type": "json",
         "unique": false,
       },
@@ -372,3 +472,5 @@ exports[`Schema parser with aliased imports 1`] = `
   },
 ]
 `;
+
+exports[`Schema parser schema definitions file 1`] = `Promise {}`;

--- a/tests/unit/__snapshots__/parser.test.ts.snap
+++ b/tests/unit/__snapshots__/parser.test.ts.snap
@@ -303,3 +303,111 @@ exports[`Schema parser schema with TSDoc 1`] = `
   },
 ]
 `;
+
+exports[`Schema parser with named imports 1`] = `
+[
+  {
+    "fields": [
+      {
+        "displayAs": "single-line",
+        "id": "string-0",
+        "name": "Name",
+        "required": true,
+        "slug": "name",
+        "type": "string",
+        "unique": false,
+      },
+      {
+        "id": "boolean-0",
+        "name": "Active",
+        "required": true,
+        "slug": "active",
+        "type": "boolean",
+        "unique": false,
+      },
+      {
+        "id": "number-0",
+        "name": "Likes",
+        "required": true,
+        "slug": "likes",
+        "type": "number",
+        "unique": false,
+      },
+      {
+        "id": "date-0",
+        "name": "ActiveAt",
+        "required": true,
+        "slug": "activeAt",
+        "type": "date",
+        "unique": false,
+      },
+      {
+        "id": "blob-0",
+        "name": "Avatar",
+        "required": true,
+        "slug": "avatar",
+        "type": "blob",
+        "unique": false,
+      },
+    ],
+    "name": "Account",
+    "pluralName": "My Accounts",
+    "pluralSlug": "myAccounts",
+    "slug": "account",
+  },
+]
+`;
+
+exports[`Schema parser with aliased imports 1`] = `
+[
+  {
+    "fields": [
+      {
+        "displayAs": "single-line",
+        "id": "string-0",
+        "name": "Name",
+        "required": true,
+        "slug": "name",
+        "type": "string",
+        "unique": false,
+      },
+      {
+        "id": "boolean-0",
+        "name": "Active",
+        "required": true,
+        "slug": "active",
+        "type": "boolean",
+        "unique": false,
+      },
+      {
+        "id": "number-0",
+        "name": "Likes",
+        "required": true,
+        "slug": "likes",
+        "type": "number",
+        "unique": false,
+      },
+      {
+        "id": "date-0",
+        "name": "ActiveAt",
+        "required": true,
+        "slug": "activeAt",
+        "type": "date",
+        "unique": false,
+      },
+      {
+        "id": "blob-0",
+        "name": "Avatar",
+        "required": true,
+        "slug": "avatar",
+        "type": "blob",
+        "unique": false,
+      },
+    ],
+    "name": "Account",
+    "pluralName": "My Accounts",
+    "pluralSlug": "myAccounts",
+    "slug": "account",
+  },
+]
+`;

--- a/tests/unit/__snapshots__/parser.test.ts.snap
+++ b/tests/unit/__snapshots__/parser.test.ts.snap
@@ -1,5 +1,44 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Schema parser throw error when plural schema is missing 1`] = `
+"The schema \`Account\` does not have a plural slug and name defined.
+
+Please define them in your schema definition file and include them in the \`Schemas\` interface:
+
+import type * as Schema from 'ronin/schema';
+
+type Accounts = Schema.Records<Account>;
+
+interface Schemas {
+  account: Account;
+  accounts: Accounts;
+}"
+`;
+
+exports[`Schema parser throw error referenced schema is not registered 1`] = `
+"The following schemas were used as a reference but weren't included in the \`Schemas\` interface:
+
+  - \`Session\` in \`Account\` (schemas/index.ts:9:13)
+
+Please include them in the \`Schemas\` interface or remove their references."
+`;
+
+exports[`Schema parser throw error schema field type cannot be determined 1`] = `
+"The type of the following fields could not be determined:
+
+  - \`Account.session\` is typed as \`ThisIsNotAValidType\` (schemas/index.ts:5:13)
+
+Please make sure that the field is typed as any of the available field types:
+
+  - \`string\`
+  - \`number\`
+  - \`boolean\`
+  - \`Date\`
+  - \`Schema.Blob\`
+  - \`Schema.JSON\`
+  - or a reference to another schema."
+`;
+
 exports[`Schema parser schema with basic field types 1`] = `
 [
   {

--- a/tests/unit/__snapshots__/parser.test.ts.snap
+++ b/tests/unit/__snapshots__/parser.test.ts.snap
@@ -1,0 +1,305 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Schema parser throw error when plural schema is missing 1`] = `
+"The schema \`Account\` does not have a plural slug and name defined.
+
+Please define them in your schema definition file and include them in the \`Schemas\` interface:
+
+import type * as Schema from 'ronin/schema';
+
+type Accounts = Schema.Records<Account>;
+
+interface Schemas {
+  account: Account;
+  accounts: Accounts;
+}"
+`;
+
+exports[`Schema parser throw error referenced schema is not registered 1`] = `
+"The following schemas were used as a reference but weren't included in the \`Schemas\` interface:
+
+  - \`Session\` in \`Account\` (schemas/index.ts:9:13)
+
+Please include them in the \`Schemas\` interface or remove their references."
+`;
+
+exports[`Schema parser throw error schema field type cannot be determined 1`] = `
+"The type of the following fields could not be determined:
+
+  - \`Account.session\` is typed as \`ThisIsNotAValidType\` (schemas/index.ts:5:13)
+
+Please make sure that the field is typed as any of the available field types:
+
+  - \`string\`
+  - \`number\`
+  - \`boolean\`
+  - \`Date\`
+  - \`Schema.Blob\`
+  - \`Schema.JSON\`
+  - or a reference to another schema."
+`;
+
+exports[`Schema parser schema with basic field types 1`] = `
+[
+  {
+    "fields": [
+      {
+        "displayAs": "single-line",
+        "id": "string-0",
+        "name": "Name",
+        "required": true,
+        "slug": "name",
+        "type": "string",
+        "unique": false,
+      },
+      {
+        "id": "boolean-0",
+        "name": "Active",
+        "required": true,
+        "slug": "active",
+        "type": "boolean",
+        "unique": false,
+      },
+      {
+        "id": "number-0",
+        "name": "Likes",
+        "required": true,
+        "slug": "likes",
+        "type": "number",
+        "unique": false,
+      },
+      {
+        "id": "date-0",
+        "name": "ActiveAt",
+        "required": true,
+        "slug": "activeAt",
+        "type": "date",
+        "unique": false,
+      },
+    ],
+    "name": "Account",
+    "pluralName": "Accounts",
+    "pluralSlug": "accounts",
+    "slug": "account",
+  },
+]
+`;
+
+exports[`Schema parser schema with referenced field type 1`] = `
+[
+  {
+    "fields": [
+      {
+        "id": "reference-0",
+        "name": "Session",
+        "required": true,
+        "schema": "session",
+        "slug": "session",
+        "type": "reference",
+        "unique": false,
+      },
+    ],
+    "name": "Account",
+    "pluralName": "Accounts",
+    "pluralSlug": "accounts",
+    "slug": "account",
+  },
+  {
+    "fields": [
+      {
+        "displayAs": "single-line",
+        "id": "string-0",
+        "name": "Device",
+        "required": true,
+        "slug": "device",
+        "type": "string",
+        "unique": false,
+      },
+    ],
+    "name": "Session",
+    "pluralName": "Sessions",
+    "pluralSlug": "sessions",
+    "slug": "session",
+  },
+]
+`;
+
+exports[`Schema parser schema with advanced field types 1`] = `
+[
+  {
+    "fields": [
+      {
+        "id": "blob-0",
+        "name": "Avatar",
+        "required": true,
+        "slug": "avatar",
+        "type": "blob",
+        "unique": false,
+      },
+      {
+        "id": "json-0",
+        "name": "Metadata",
+        "required": true,
+        "slug": "metadata",
+        "type": "json",
+        "unique": false,
+      },
+    ],
+    "name": "Account",
+    "pluralName": "Accounts",
+    "pluralSlug": "accounts",
+    "slug": "account",
+  },
+]
+`;
+
+exports[`Schema parser schema with generic field types 1`] = `
+[
+  {
+    "fields": [
+      {
+        "id": "json-0",
+        "meta": {
+          "type": "[{ name: string }]",
+        },
+        "name": "Metadata1",
+        "required": true,
+        "slug": "metadata1",
+        "type": "json",
+        "unique": false,
+      },
+      {
+        "id": "json-0",
+        "meta": [
+          {
+            "name": "name",
+            "required": true,
+            "type": "string",
+          },
+        ],
+        "name": "Metadata1",
+        "required": true,
+        "slug": "metadata1",
+        "type": "json",
+        "unique": false,
+      },
+      {
+        "id": "json-0",
+        "meta": [
+          {
+            "name": "name",
+            "required": true,
+            "type": "string",
+          },
+          {
+            "name": "status",
+            "required": false,
+            "type": "enum",
+            "value": [
+              "active",
+              "inactive",
+            ],
+          },
+          {
+            "children": [
+              {
+                "name": "name",
+                "required": true,
+                "type": "string",
+              },
+              {
+                "name": "count",
+                "required": false,
+                "type": "number",
+              },
+            ],
+            "name": "users",
+            "required": true,
+            "type": "array",
+          },
+          {
+            "children": [
+              {
+                "name": "device",
+                "required": true,
+                "type": "string",
+              },
+              {
+                "name": "likes",
+                "required": false,
+                "type": "number",
+              },
+              {
+                "name": "active",
+                "required": true,
+                "type": "boolean",
+              },
+              {
+                "children": [
+                  {
+                    "name": "createdAt",
+                    "required": true,
+                    "type": "date",
+                  },
+                ],
+                "name": "dates",
+                "required": true,
+                "type": "object",
+              },
+            ],
+            "name": "metadata",
+            "required": true,
+            "type": "object",
+          },
+        ],
+        "name": "Metadata2",
+        "required": true,
+        "slug": "metadata2",
+        "type": "json",
+        "unique": false,
+      },
+    ],
+    "name": "Account",
+    "pluralName": "Accounts",
+    "pluralSlug": "accounts",
+    "slug": "account",
+  },
+]
+`;
+
+exports[`Schema parser schema with TSDoc 1`] = `
+[
+  {
+    "fields": [
+      {
+        "displayAs": "single-line",
+        "id": "string-0",
+        "name": "User name",
+        "required": true,
+        "slug": "name",
+        "type": "string",
+        "unique": false,
+      },
+      {
+        "description": "This is a field description.",
+        "details": {
+          "maxSize": "100",
+          "minSize": "1",
+          "pattern": "^[A-Z]{2}$",
+        },
+        "displayAs": "single-line",
+        "id": "string-0",
+        "name": "User's country",
+        "required": true,
+        "slug": "country",
+        "type": "string",
+        "unique": false,
+      },
+    ],
+    "name": "Account",
+    "pluralName": "Accounts",
+    "pluralSlug": "accounts",
+    "slug": "account",
+  },
+]
+`;

--- a/tests/unit/__snapshots__/parser.test.ts.snap
+++ b/tests/unit/__snapshots__/parser.test.ts.snap
@@ -513,3 +513,9 @@ exports[`Schema parser with aliased imports 1`] = `
 `;
 
 exports[`Schema parser schema definitions file 1`] = `Promise {}`;
+
+exports[`Schema parser schema with unsupported property type in generic field types 1`] = `
+"Unsupported property type \`name(): void;\` in Schema.JSON<{ 
+                name(): void; 
+            }>"
+`;

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -236,4 +236,58 @@ describe('Schema parser', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  test('with named imports', () => {
+    const schema = `
+        import { Record, Records, Blob } from 'ronin/schema';
+
+        type Account = Record<{
+            name: string;
+            active: boolean;
+            likes: number;
+            activeAt: Date;
+            avatar: Blob;
+        }>
+
+        type MyAccounts = Records<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                myAccounts: MyAccounts;
+            }
+        }
+        `;
+
+    const result = parseSchemaDefinitions(schema, 'schemas/index.ts');
+
+    expect(result).toMatchSnapshot();
+  });
+
+  test('with aliased imports', () => {
+    const schema = `
+        import { Record as SchemaRecord, Records as SchemaRecords, Blob as RoninBlob } from 'ronin/schema';
+
+        type Account = SchemaRecord<{
+            name: string;
+            active: boolean;
+            likes: number;
+            activeAt: Date;
+            avatar: RoninBlob;
+        }>
+
+        type MyAccounts = SchemaRecords<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                myAccounts: MyAccounts;
+            }
+        }
+        `;
+
+    const result = parseSchemaDefinitions(schema, 'schemas/index.ts');
+
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1,6 +1,9 @@
+import { unlink } from 'node:fs/promises';
+import path from 'node:path';
+
 import { describe, expect, test } from 'bun:test';
 
-import { parseSchemaDefinitions } from '@/src/bin/parser';
+import { parseSchemaDefinitionFile, parseSchemaDefinitions } from '@/src/bin/parser';
 
 describe('Schema parser', () => {
   test('throw error when plural schema is missing', () => {
@@ -315,6 +318,38 @@ Please make sure that the field is typed as any of the available field types:
         `;
 
     const result = parseSchemaDefinitions(schema, 'schemas/index.ts');
+
+    expect(result).toMatchSnapshot();
+  });
+
+  test('schema definitions file', async () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Account = Schema.Record<{
+            name: string;
+            active: boolean;
+            likes: number;
+            activeAt: Date;
+        }>
+
+        type Accounts = Schema.Records<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+            }
+        }
+        `;
+
+    const filePath = 'schemas/index.ts';
+
+    await Bun.write(filePath, schema);
+
+    const result = parseSchemaDefinitionFile(filePath);
+
+    await unlink(filePath);
 
     expect(result).toMatchSnapshot();
   });

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -18,11 +18,20 @@ describe('Schema parser', () => {
         }
         `;
 
-    let errorMessage;
+    const error = `The schema \`Account\` does not have a plural slug and name defined.
 
-    parseSchemaDefinitions(schema, 'schemas/index.ts', (error) => (errorMessage = error));
+Please define them in your schema definition file and include them in the \`Schemas\` interface:
 
-    expect(errorMessage).toMatchSnapshot();
+import type * as Schema from 'ronin/schema';
+
+type Accounts = Schema.Records<Account>;
+
+interface Schemas {
+  account: Account;
+  accounts: Accounts;
+}`;
+
+    expect(() => parseSchemaDefinitions(schema, 'schemas/index.ts')).toThrow(error);
   });
 
   test('throw error referenced schema is not registered', () => {
@@ -48,11 +57,13 @@ describe('Schema parser', () => {
         }
         `;
 
-    let errorMessage;
+    const error = `The following schemas were used as a reference but weren't included in the \`Schemas\` interface:
 
-    parseSchemaDefinitions(schema, 'schemas/index.ts', (error) => (errorMessage = error));
+  - \`Session\` in \`Account\` (schemas/index.ts:9:13)
 
-    expect(errorMessage).toMatchSnapshot();
+Please include them in the \`Schemas\` interface or remove their references.`;
+
+    expect(() => parseSchemaDefinitions(schema, 'schemas/index.ts')).toThrow(error);
   });
 
   test('throw error schema field type cannot be determined', () => {
@@ -73,11 +84,21 @@ describe('Schema parser', () => {
         }
         `;
 
-    let errorMessage;
+    const error = `The type of the following fields could not be determined:
 
-    parseSchemaDefinitions(schema, 'schemas/index.ts', (error) => (errorMessage = error));
+  - \`Account.session\` is typed as \`ThisIsNotAValidType\` (schemas/index.ts:5:13)
 
-    expect(errorMessage).toMatchSnapshot();
+Please make sure that the field is typed as any of the available field types:
+
+  - \`string\`
+  - \`number\`
+  - \`boolean\`
+  - \`Date\`
+  - \`Schema.Blob\`
+  - \`Schema.JSON\`
+  - or a reference to another schema.`;
+
+    expect(() => parseSchemaDefinitions(schema, 'schemas/index.ts')).toThrow(error);
   });
 
   test('schema with basic field types', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parseSchemaDefinitions } from '@/src/bin/parser';
+
+describe('Schema parser', () => {
+  test('throw error when plural schema is missing', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Account = Schema.Record<{
+            name: string
+        }>
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+            }
+        }
+        `;
+
+    let errorMessage;
+
+    parseSchemaDefinitions(schema, 'schemas/index.ts', (error) => (errorMessage = error));
+
+    expect(errorMessage).toMatchSnapshot();
+  });
+
+  test('throw error referenced schema is not registered', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Session = Schema.Record<{
+            device: string;
+        }>
+            
+        type Account = Schema.Record<{
+            session: Session;
+        }>
+
+        type Accounts = Schema.Records<Account>;
+        type Sessions = Schema.Records<Session>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+            }
+        }
+        `;
+
+    let errorMessage;
+
+    parseSchemaDefinitions(schema, 'schemas/index.ts', (error) => (errorMessage = error));
+
+    expect(errorMessage).toMatchSnapshot();
+  });
+
+  test('throw error schema field type cannot be determined', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Account = Schema.Record<{
+            session: ThisIsNotAValidType
+        }>
+
+        type Accounts = Schema.Records<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+            }
+        }
+        `;
+
+    let errorMessage;
+
+    parseSchemaDefinitions(schema, 'schemas/index.ts', (error) => (errorMessage = error));
+
+    expect(errorMessage).toMatchSnapshot();
+  });
+
+  test('schema with basic field types', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Account = Schema.Record<{
+            name: string;
+            active: boolean;
+            likes: number;
+            activeAt: Date;
+        }>
+
+        type Accounts = Schema.Records<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+            }
+        }
+        `;
+
+    const result = parseSchemaDefinitions(schema, 'schemas/index.ts');
+
+    expect(result).toMatchSnapshot();
+  });
+
+  test('schema with referenced field type', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Session = Schema.Record<{
+            device: string;
+        }>
+
+        type Account = Schema.Record<{
+            session: Session;
+        }>
+
+        type Accounts = Schema.Records<Account>;
+        type Sessions = Schema.Records<Session>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+                
+                session: Session;
+                sessions: Sessions;
+            }
+        }
+        `;
+
+    const result = parseSchemaDefinitions(schema, 'schemas/index.ts');
+
+    expect(result).toMatchSnapshot();
+  });
+
+  test('schema with advanced field types', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Account = Schema.Record<{
+            avatar: Schema.Blob;
+            metadata: Schema.JSON;
+        }>
+
+        type Accounts = Schema.Records<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+            }
+        }
+        `;
+
+    const result = parseSchemaDefinitions(schema, 'schemas/index.ts');
+
+    expect(result).toMatchSnapshot();
+  });
+
+  test('schema with generic field types', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Account = Schema.Record<{
+            metadata1: Schema.JSON<[{ name: string }]>;
+            metadata1: Schema.JSON<{ name: string }>;
+            metadata2: Schema.JSON<{ 
+                name: string; 
+                status?: "active" | "inactive";
+                users: { 
+                    name: string; 
+                    count?: number 
+                }[];
+                metadata: {
+                    device: string;
+                    likes?: number;
+                    active: boolean;
+                    dates: {
+                        createdAt: Date;
+                    }
+                };
+            }>;
+        }>
+
+        type Accounts = Schema.Records<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+            }
+        }
+        `;
+
+    const result = parseSchemaDefinitions(schema, 'schemas/index.ts');
+
+    expect(result).toMatchSnapshot();
+  });
+
+  test('schema with TSDoc', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Account = Schema.Record<{
+            /**
+             * User name
+            */
+            name: string;
+            /**
+             * User's country
+             * 
+             * This is a field description.
+             * 
+             * @maxSize 100
+             * @minSize 1
+             * @pattern ^[A-Z]{2}$
+            */
+            country: string;
+        }>
+
+        type Accounts = Schema.Records<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+            }
+        }
+        `;
+
+    const result = parseSchemaDefinitions(schema, 'schemas/index.ts');
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -103,6 +103,33 @@ Please make sure that the field is typed as any of the available field types:
     expect(() => parseSchemaDefinitions(schema, 'schemas/index.ts')).toThrow(error);
   });
 
+  test('schema with auto-generated IDs', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Account = Schema.Record<{
+            name: string;
+        }>
+
+        type Accounts = Schema.Records<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+            }
+        }
+        `;
+
+    process.env.NODE_ENV = 'development';
+    const result = parseSchemaDefinitions(schema, 'schemas/index.ts');
+    process.env.NODE_ENV = 'test';
+
+    const fieldId = result[0].fields[0].id;
+
+    expect(fieldId).toMatch(/^string-[a-zA-Z0-9]{24}$/);
+  });
+
   test('schema with basic field types', () => {
     const schema = `
         import * as Schema from 'ronin/schema';

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -187,11 +187,17 @@ Please make sure that the field is typed as any of the available field types:
         import * as Schema from 'ronin/schema';
 
         type Account = Schema.Record<{
-            metadata1: Schema.JSON<[{ name: string }]>;
-            metadata1: Schema.JSON<{ name: string }>;
-            metadata2: Schema.JSON<{ 
+            metadata1: Schema.JSON<Schema.Blob>;
+            metadata2: Schema.JSON<"option-1">;
+            metadata3: Schema.JSON<"option-1" | "option-2">;
+            metadata4: Schema.JSON<{ name: string }>;
+            metadata5: Schema.JSON<{ name: string }[]>;
+            metadata6: Schema.JSON<[{ name: string }]>;
+            metadata7: Schema.JSON<{ constant: "ronin" }>;
+            metadata8: Schema.JSON<{ 
                 name: string; 
                 status?: "active" | "inactive";
+                avatar: Schema.Blob<{ type: "images" }>;
                 users: { 
                     name: string; 
                     count?: number 
@@ -200,6 +206,7 @@ Please make sure that the field is typed as any of the available field types:
                     device: string;
                     likes?: number;
                     active: boolean;
+                    array: Array<string>;
                     dates: {
                         createdAt: Date;
                     }

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -20,20 +20,14 @@ describe('Schema parser', () => {
         }
         `;
 
-    const error = `The schema \`Account\` does not have a plural slug and name defined.
-
-Please define them in your schema definition file and include them in the \`Schemas\` interface:
-
-import type * as Schema from 'ronin/schema';
-
-type Accounts = Schema.Records<Account>;
-
-interface Schemas {
-  account: Account;
-  accounts: Accounts;
-}`;
-
-    expect(() => parseSchemaDefinitions(schema, 'schemas/index.ts')).toThrow(error);
+    expect(() => {
+      try {
+        parseSchemaDefinitions(schema, 'schemas/index.ts');
+      } catch (err) {
+        expect((err as Error).message).toMatchSnapshot();
+        throw err;
+      }
+    }).toThrow(Error);
   });
 
   test('throw error referenced schema is not registered', () => {
@@ -59,13 +53,14 @@ interface Schemas {
         }
         `;
 
-    const error = `The following schemas were used as a reference but weren't included in the \`Schemas\` interface:
-
-  - \`Session\` in \`Account\` (schemas/index.ts:9:13)
-
-Please include them in the \`Schemas\` interface or remove their references.`;
-
-    expect(() => parseSchemaDefinitions(schema, 'schemas/index.ts')).toThrow(error);
+    expect(() => {
+      try {
+        parseSchemaDefinitions(schema, 'schemas/index.ts');
+      } catch (err) {
+        expect((err as Error).message).toMatchSnapshot();
+        throw err;
+      }
+    }).toThrow(Error);
   });
 
   test('throw error schema field type cannot be determined', () => {
@@ -86,21 +81,14 @@ Please include them in the \`Schemas\` interface or remove their references.`;
         }
         `;
 
-    const error = `The type of the following fields could not be determined:
-
-  - \`Account.session\` is typed as \`ThisIsNotAValidType\` (schemas/index.ts:5:13)
-
-Please make sure that the field is typed as any of the available field types:
-
-  - \`string\`
-  - \`number\`
-  - \`boolean\`
-  - \`Date\`
-  - \`Schema.Blob\`
-  - \`Schema.JSON\`
-  - or a reference to another schema.`;
-
-    expect(() => parseSchemaDefinitions(schema, 'schemas/index.ts')).toThrow(error);
+    expect(() => {
+      try {
+        parseSchemaDefinitions(schema, 'schemas/index.ts');
+      } catch (err) {
+        expect((err as Error).message).toMatchSnapshot();
+        throw err;
+      }
+    }).toThrow(Error);
   });
 
   test('schema with auto-generated IDs', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -246,6 +246,36 @@ describe('Schema parser', () => {
     expect(result).toMatchSnapshot();
   });
 
+  test('schema with unsupported property type in generic field types', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Account = Schema.Record<{
+            metadata: Schema.JSON<{ 
+                name(): void; 
+            }>;
+        }>
+
+        type Accounts = Schema.Records<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+            }
+        }
+        `;
+
+    expect(() => {
+      try {
+        parseSchemaDefinitions(schema, 'schemas/index.ts');
+      } catch (err) {
+        expect((err as Error).message).toMatchSnapshot();
+        throw err;
+      }
+    }).toThrow(Error);
+  });
+
   test('schema with TSDoc', () => {
     const schema = `
         import * as Schema from 'ronin/schema';

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1,5 +1,4 @@
 import { unlink } from 'node:fs/promises';
-import path from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
 

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -422,6 +422,14 @@ describe('Schema parser', () => {
     expect(result).toMatchSnapshot();
   });
 
+  test('throw error when definitions file does not exist', async () => {
+    const filePath = 'schemas/index.ts';
+
+    expect(parseSchemaDefinitionFile(filePath)).rejects.toThrow(
+      /The given path to the schema definition file does not exist: .*\/schemas\/index\.ts/,
+    );
+  });
+
   test('schema definitions file', async () => {
     const schema = `
         import * as Schema from 'ronin/schema';
@@ -452,13 +460,5 @@ describe('Schema parser', () => {
     await unlink(filePath);
 
     expect(result).toMatchSnapshot();
-  });
-
-  test('throw error when definitions file does not exist', async () => {
-    const filePath = 'schemas/index.ts';
-
-    expect(parseSchemaDefinitionFile(filePath)).rejects.toThrow(
-      /The given path to the schema definition file does not exist: .*\/schemas\/index\.ts/,
-    );
   });
 });

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -353,4 +353,12 @@ Please make sure that the field is typed as any of the available field types:
 
     expect(result).toMatchSnapshot();
   });
+
+  test('throw error when definitions file does not exist', async () => {
+    const filePath = 'schemas/index.ts';
+
+    expect(parseSchemaDefinitionFile(filePath)).rejects.toThrow(
+      /The given path to the schema definition file does not exist: .*\/schemas\/index\.ts/,
+    );
+  });
 });

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -91,6 +91,34 @@ describe('Schema parser', () => {
     }).toThrow(Error);
   });
 
+  test('throw error schema field does not have a type', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Account = Schema.Record<{
+            session
+        }>
+
+        type Accounts = Schema.Records<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+            }
+        }
+        `;
+
+    expect(() => {
+      try {
+        parseSchemaDefinitions(schema, 'schemas/index.ts');
+      } catch (err) {
+        expect((err as Error).message).toMatchSnapshot();
+        throw err;
+      }
+    }).toThrow(Error);
+  });
+
   test('schema with auto-generated IDs', () => {
     const schema = `
         import * as Schema from 'ronin/schema';
@@ -254,6 +282,34 @@ describe('Schema parser', () => {
             metadata: Schema.JSON<{ 
                 name(): void; 
             }>;
+        }>
+
+        type Accounts = Schema.Records<Account>;
+
+        declare module 'ronin' {
+            interface Schemas {
+                account: Account;
+                accounts: Accounts;
+            }
+        }
+        `;
+
+    expect(() => {
+      try {
+        parseSchemaDefinitions(schema, 'schemas/index.ts');
+      } catch (err) {
+        expect((err as Error).message).toMatchSnapshot();
+        throw err;
+      }
+    }).toThrow(Error);
+  });
+
+  test('schema with undefined property type in generic field types', () => {
+    const schema = `
+        import * as Schema from 'ronin/schema';
+
+        type Account = Schema.Record<{
+            metadata: Schema.JSON<{ name }>;
         }>
 
         type Accounts = Schema.Records<Account>;

--- a/tests/unit/strings.test.ts
+++ b/tests/unit/strings.test.ts
@@ -1,12 +1,68 @@
-import { expect, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 
+import { convertToReadableText } from '@/src/bin/parser/utils';
 import { toDashCase } from '@/src/utils/helpers';
 
-test('correctly convert strings to dash case', async () => {
-  expect(toDashCase('superLongSlug')).toBe('super-long-slug');
-  expect(toDashCase('even-MoreWords')).toBe('even-more-words');
-  expect(toDashCase('oh wow okay')).toBe('oh-wow-okay');
-  expect(toDashCase('')).toBe('');
-  expect(toDashCase(null)).toBe('');
-  expect(toDashCase(undefined)).toBe('');
+describe('toDashCase', () => {
+  test('correctly convert camelCase to dash case', async () => {
+    expect(toDashCase('superLongSlug')).toBe('super-long-slug');
+  });
+
+  test('correctly convert mixed case to dash case', async () => {
+    expect(toDashCase('even-MoreWords')).toBe('even-more-words');
+  });
+
+  test('correctly convert space-separated words to dash case', async () => {
+    expect(toDashCase('oh wow okay')).toBe('oh-wow-okay');
+  });
+
+  test('correctly handle empty string', async () => {
+    expect(toDashCase('')).toBe('');
+  });
+
+  test('correctly handle null input', async () => {
+    expect(toDashCase(null)).toBe('');
+  });
+
+  test('correctly handle undefined input', async () => {
+    expect(toDashCase(undefined)).toBe('');
+  });
+});
+
+describe('convertToReadableText', () => {
+  test('should insert spaces before uppercase letters', () => {
+    expect(convertToReadableText('helloWorld')).toBe('Hello World');
+  });
+
+  test('should insert spaces between letters and digits', () => {
+    expect(convertToReadableText('hello123world')).toBe('Hello 123 World');
+  });
+
+  test('should handle strings with both letters and digits', () => {
+    expect(convertToReadableText('helloWorld123')).toBe('Hello World 123');
+  });
+
+  test('should return null for null input', () => {
+    expect(convertToReadableText(null)).toBeNull();
+  });
+
+  test('should return null for undefined input', () => {
+    expect(convertToReadableText(undefined)).toBeNull();
+  });
+
+  test('should return an empty string for an empty string input', () => {
+    expect(convertToReadableText('')).toBe('');
+  });
+
+  test('should handle strings with multiple digits together', () => {
+    expect(convertToReadableText('abc123def456')).toBe('Abc 123 Def 456');
+  });
+
+  test('should handle strings with no uppercase letters or digits', () => {
+    expect(convertToReadableText('helloworld')).toBe('Helloworld');
+  });
+
+  test('should handle strings with only digits', () => {
+    expect(convertToReadableText('123456')).toBe('123456');
+  });
 });


### PR DESCRIPTION
This pull request improves the schema definitions parser in multiple ways:

Improvements:

- Split up the parser file into multiple files and moved into a dedicated folder
- Added TSDoc to all related functions
- Added tests for the parser
- Removed deprecated schema types

New features:

- Made it possible to parse type arguments in schema definitions. e.g. `jsonField: Schema.JSON<{ name: string }>`