### PR TITLE
Return Query When Used with Schemas in Code

### DIFF
--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -66,7 +66,11 @@ export const getSyntaxProxy = (
 
               const query = { [queryType]: expanded };
 
-              if (IN_BATCH_ASYNC?.getStore() || IN_BATCH_SYNC) {
+              if (
+                IN_BATCH_ASYNC?.getStore() ||
+                IN_BATCH_SYNC ||
+                import.meta.env.IS_SCHEMAS_IN_CODE === '1'
+              ) {
                 return { query, options };
               }
 


### PR DESCRIPTION
To retrieve the query without executing it within the schemas in code, we now check if the environment variable for schemas in code is set.