### PR TITLE
Allow for nesting queries

### DIFF
--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -2,6 +2,7 @@ import type { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { Query } from '@/src/types/query';
 import type { PromiseTuple, QueryHandlerOptions, QueryItem } from '@/src/types/utils';
+import { RONIN_SCHEMA_SYMBOLS } from '@/src/utils/constants';
 import { objectFromAccessor } from '@/src/utils/helpers';
 
 /**
@@ -57,8 +58,20 @@ export const getSyntaxProxy = (
 
           return new Proxy(proxyTargetFunction, {
             apply(_target: any, _thisArg: any, args: Array<any>) {
-              const value = args[0];
+              let value = args[0];
               const options = args[1];
+
+              if (options?.asyncContext) IN_BATCH_ASYNC = options.asyncContext;
+
+              if (typeof value === 'function') {
+                if (!IN_BATCH_ASYNC)
+                  throw new Error(
+                    'The `asyncContext` option must be provided when using sub queries.',
+                  );
+                const subQueryDetails = IN_BATCH_ASYNC.run(true, () => value());
+                value = { [RONIN_SCHEMA_SYMBOLS.QUERY]: subQueryDetails.query };
+              }
+
               const expanded = objectFromAccessor(
                 path.join('.'),
                 typeof value === 'undefined' ? {} : value,

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -61,15 +61,14 @@ export const getSyntaxProxy = (
               let value = args[0];
               const options = args[1];
 
-              if (options?.asyncContext) IN_BATCH_ASYNC = options.asyncContext;
-
               if (typeof value === 'function') {
-                if (!IN_BATCH_ASYNC)
-                  throw new Error(
-                    'The `asyncContext` option must be provided when using sub queries.',
-                  );
-                const subQueryDetails = IN_BATCH_ASYNC.run(true, () => value());
-                value = { [RONIN_SCHEMA_SYMBOLS.QUERY]: subQueryDetails.query };
+                // Since `value()` is synchronous, `IN_BATCH_SYNC` should not affect any
+                // other queries somewhere else in the app, even if those are run inside
+                // an asynchronous function, so we don't need to use `IN_BATCH_ASYNC`,
+                // which avoids the need to pass it as an option to the client.
+                IN_BATCH_SYNC = true;
+                value = { [RONIN_SCHEMA_SYMBOLS.QUERY]: value().query };
+                IN_BATCH_SYNC = false;
               }
 
               const expanded = objectFromAccessor(

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,13 @@
+/**
+ * A list of placeholders that can be located inside queries after those queries were
+ * serialized into JSON objects.
+ *
+ * These placeholders are used to represent special keys and values. For example, if a
+ * query is nested into a query, the nested query will be marked with `__RONIN_QUERY`,
+ * which allows for distinguishing that nested query from an object of instructions.
+ */
+export const RONIN_SCHEMA_SYMBOLS = {
+  QUERY: '__RONIN_QUERY',
+  FIELD: '__RONIN_FIELD_',
+  VALUE: '__RONIN_VALUE',
+} as const;

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -1,12 +1,43 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, spyOn, test } from 'bun:test';
 
 import { get } from '@/src/index';
 import type { QueryItem } from '@/src/types/utils';
-import { getBatchProxy } from '@/src/utils';
+import { getBatchProxy, getSyntaxProxy } from '@/src/utils';
 
 describe('syntax proxy', () => {
+  test('using sub query', async () => {
+    const options = {
+      asyncContext: new AsyncLocalStorage(),
+    };
+
+    const getQueryHandler = { callback: () => undefined };
+    const getQueryHandlerSpy = spyOn(getQueryHandler, 'callback');
+    const createQueryHandler = { callback: () => undefined };
+    const createQueryHandlerSpy = spyOn(createQueryHandler, 'callback');
+
+    const getProxy = getSyntaxProxy('get', getQueryHandlerSpy);
+    const createProxy = getSyntaxProxy('create', createQueryHandlerSpy);
+
+    createProxy.accounts.with(() => getProxy.oldAccounts(), options);
+
+    const finalQuery = {
+      create: {
+        accounts: {
+          with: {
+            __RONIN_QUERY: {
+              get: { oldAccounts: {} },
+            },
+          },
+        },
+      },
+    };
+
+    expect(getQueryHandlerSpy).not.toHaveBeenCalled();
+    expect(createQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, options);
+  });
+
   test('using async context', async () => {
     const details = getBatchProxy(
       () => [get.account()],

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -8,10 +8,6 @@ import { getBatchProxy, getSyntaxProxy } from '@/src/utils';
 
 describe('syntax proxy', () => {
   test('using sub query', async () => {
-    const options = {
-      asyncContext: new AsyncLocalStorage(),
-    };
-
     const getQueryHandler = { callback: () => undefined };
     const getQueryHandlerSpy = spyOn(getQueryHandler, 'callback');
     const createQueryHandler = { callback: () => undefined };
@@ -20,7 +16,7 @@ describe('syntax proxy', () => {
     const getProxy = getSyntaxProxy('get', getQueryHandlerSpy);
     const createProxy = getSyntaxProxy('create', createQueryHandlerSpy);
 
-    createProxy.accounts.with(() => getProxy.oldAccounts(), options);
+    createProxy.accounts.with(() => getProxy.oldAccounts());
 
     const finalQuery = {
       create: {
@@ -35,7 +31,7 @@ describe('syntax proxy', () => {
     };
 
     expect(getQueryHandlerSpy).not.toHaveBeenCalled();
-    expect(createQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, options);
+    expect(createQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
   });
 
   test('using async context', async () => {


### PR DESCRIPTION
This change makes it possible to nest a query into another query like so:

```typescript
import { get, create } from 'ronin';

await create.newAccounts.with(() => get.oldAccounts());
```

Just like any other value for the query, sub queries can be placed at any level.