### PR TITLE
Added support for function chaining in batches

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -39,7 +39,8 @@
       },
       "nursery": {
         "all": true,
-        "useSortedClasses": "warn"
+        "useSortedClasses": "warn",
+        "useExplicitType": "off"
       },
       "performance": {
         "all": true,

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -70,6 +70,9 @@ export const getSyntaxProxy = (
               let value = args[0];
               const options = args[1];
 
+              // If a function is provided as the argument for the query, call it and make
+              // all queries within it think they are running inside a batch transaction,
+              // in order to retrieve their serialized values.
               if (typeof value === 'function') {
                 // Since `value()` is synchronous, `IN_BATCH_SYNC` should not affect any
                 // other queries somewhere else in the app, even if those are run inside
@@ -80,15 +83,26 @@ export const getSyntaxProxy = (
                 IN_BATCH_SYNC = false;
               }
 
+              // If the function call is happening after an existing function call in the
+              // same query, the existing query will be available as `target.query`, and
+              // we should extend it. If none is available, we should create a new query.
               const query = target.query || {};
               const targetValue = typeof value === 'undefined' ? {} : value;
 
               setProperty(query, `${queryType}.${path.join('.')}`, targetValue);
 
+              // If the function call is happening inside a batch, return a new proxy, to
+              // allow for continuing to chain `get` accessors and function calls after
+              // existing function calls in the same query.
               if (IN_BATCH_ASYNC?.getStore() || IN_BATCH_SYNC) {
+                // To ensure that `get` accessor calls are mounted to the same level as
+                // the function after which they are called, we need to remove the last
+                // path segment.
                 const newPath = path.slice(0, -1);
                 const details: BatchDetails = { query };
 
+                // Only add options if any are available, to avoid adding a property that
+                // holds an `undefined` value.
                 if (options) details.options = options;
 
                 return createProxy(newPath, details);
@@ -98,10 +112,14 @@ export const getSyntaxProxy = (
             },
 
             get(target: any, nextProp: string, receiver: any): any {
+              // If the target object of the proxy has a static property that matches the
+              // provided property name, return its value.
               if (Object.hasOwn(target, nextProp)) {
                 return Reflect.get(target, nextProp, receiver);
               }
 
+              // If the target object does not have a matching static property, return a
+              // new proxy, to allow for chaining `get` accessors.
               return createProxy(path.concat([nextProp]), target);
             },
           });

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -3,7 +3,12 @@ import type { AsyncLocalStorage } from 'node:async_hooks';
 import type { Query } from '@/src/types/query';
 import type { PromiseTuple, QueryHandlerOptions, QueryItem } from '@/src/types/utils';
 import { RONIN_SCHEMA_SYMBOLS } from '@/src/utils/constants';
-import { objectFromAccessor } from '@/src/utils/helpers';
+import { setProperty } from '@/src/utils/helpers';
+
+interface BatchDetails {
+  query: Query;
+  options?: Record<string, unknown>;
+}
 
 /**
  * Used to track whether queries run in batches if `AsyncLocalStorage` is
@@ -48,7 +53,7 @@ export const getSyntaxProxy = (
     {},
     {
       get(_target: any, prop: string) {
-        function createProxy(path: Array<string>, customTarget?: object) {
+        function createProxy(path: Array<string>, customTarget?: BatchDetails) {
           const proxyTargetFunction = () => {};
 
           // This is workaround to avoid "uncalled functions" in the test
@@ -71,28 +76,25 @@ export const getSyntaxProxy = (
                 IN_BATCH_SYNC = false;
               }
 
-              const expanded = objectFromAccessor(
-                path.join('.'),
-                typeof value === 'undefined' ? {} : value,
-              );
+              const query = customTarget?.query || {};
+              const targetValue = typeof value === 'undefined' ? {} : value;
 
-              const query = { [queryType]: expanded };
+              setProperty(query, `${queryType}.${path.join('.')}`, targetValue);
 
               if (IN_BATCH_ASYNC?.getStore() || IN_BATCH_SYNC) {
                 const newPath = path.slice(0, -1);
-                const details = { query, path: newPath };
+                const details: BatchDetails = { query };
 
                 if (options) details.options = options;
 
                 return createProxy(newPath, details);
-                // return { query, options, ...targets };
               }
 
               return queryHandler(query, options);
             },
 
             get(target: any, nextProp: string, receiver: any): any {
-              if (customTarget && Object.hasOwn(customTarget, nextProp)) {
+              if (Object.hasOwn(target, nextProp)) {
                 return Reflect.get(target, nextProp, receiver);
               }
 

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -48,7 +48,7 @@ export const getSyntaxProxy = (
     {},
     {
       get(_target: any, prop: string) {
-        function createProxy(path: Array<string>) {
+        function createProxy(path: Array<string>, customTarget?: object) {
           const proxyTargetFunction = () => {};
 
           // This is workaround to avoid "uncalled functions" in the test
@@ -56,7 +56,7 @@ export const getSyntaxProxy = (
           // function is called when it's called via a Proxy.
           proxyTargetFunction();
 
-          return new Proxy(proxyTargetFunction, {
+          return new Proxy(customTarget || proxyTargetFunction, {
             apply(_target: any, _thisArg: any, args: Array<any>) {
               let value = args[0];
               const options = args[1];
@@ -79,13 +79,23 @@ export const getSyntaxProxy = (
               const query = { [queryType]: expanded };
 
               if (IN_BATCH_ASYNC?.getStore() || IN_BATCH_SYNC) {
-                return { query, options };
+                const newPath = path.slice(0, -1);
+                const details = { query, path: newPath };
+  
+                if (options) details.options = options;
+
+                return createProxy(newPath, details);
+                // return { query, options, ...targets };
               }
 
               return queryHandler(query, options);
             },
 
-            get(_target: any, nextProp: string): any {
+            get(target: any, nextProp: string, receiver: any): any {
+              if (customTarget && Object.hasOwn(customTarget, nextProp)) {
+                return Reflect.get(target, nextProp, receiver);
+              }
+
               return createProxy(path.concat([nextProp]));
             },
           });

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -81,7 +81,7 @@ export const getSyntaxProxy = (
               if (IN_BATCH_ASYNC?.getStore() || IN_BATCH_SYNC) {
                 const newPath = path.slice(0, -1);
                 const details = { query, path: newPath };
-  
+
                 if (options) details.options = options;
 
                 return createProxy(newPath, details);

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -53,7 +53,7 @@ export const getSyntaxProxy = (
     {},
     {
       get(_target: any, prop: string) {
-        function createProxy(path: Array<string>, customTarget?: BatchDetails) {
+        function createProxy(path: Array<string>, targetProps?: BatchDetails) {
           const proxyTargetFunction = () => {};
 
           // This is workaround to avoid "uncalled functions" in the test
@@ -61,8 +61,12 @@ export const getSyntaxProxy = (
           // function is called when it's called via a Proxy.
           proxyTargetFunction();
 
-          return new Proxy(customTarget || proxyTargetFunction, {
-            apply(_target: any, _thisArg: any, args: Array<any>) {
+          // Since the proxy target must always be a function (so that it can be called),
+          // we need to assign properties to the function itself.
+          if (targetProps) Object.assign(proxyTargetFunction, targetProps);
+
+          return new Proxy(proxyTargetFunction, {
+            apply(target: any, _thisArg: any, args: Array<any>) {
               let value = args[0];
               const options = args[1];
 
@@ -76,7 +80,7 @@ export const getSyntaxProxy = (
                 IN_BATCH_SYNC = false;
               }
 
-              const query = customTarget?.query || {};
+              const query = target.query || {};
               const targetValue = typeof value === 'undefined' ? {} : value;
 
               setProperty(query, `${queryType}.${path.join('.')}`, targetValue);
@@ -98,7 +102,7 @@ export const getSyntaxProxy = (
                 return Reflect.get(target, nextProp, receiver);
               }
 
-              return createProxy(path.concat([nextProp]));
+              return createProxy(path.concat([nextProp]), target);
             },
           });
         }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,17 +1,6 @@
 import type { QueryHandlerOptions } from '@/src/types/utils';
 
 /**
- * Construct a new object from a "dot string" property accessor.
- *
- * @param accessor - Accessor to construct object from.
- * @param value - Value to set the given accessor to.
- *
- * @returns Object constructed from the given accessor and value.
- */
-export const objectFromAccessor = (accessor: string, value: unknown): unknown =>
-  setProperty({}, accessor, value);
-
-/**
  * Splits the given path into an array of so-called segments. This is done by
  * splitting the path on the `.` character, but only if it's not preceded by a
  * `\` character. This is done to allow for setting values on nested records,
@@ -78,7 +67,7 @@ const setPropertyViaPathSegments = (
   }
 };
 
-const setProperty = <T extends object, K>(obj: T, path: string, value: K): T => {
+export const setProperty = <T extends object, K>(obj: T, path: string, value: K): T => {
   const segments = getPathSegments(path);
   setPropertyViaPathSegments(obj, segments, value);
   return obj;

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -94,9 +94,7 @@ describe('syntax proxy', () => {
     const queryList: Array<QueryItem> = [];
 
     getBatchProxy(
-      () => {
-        return [getProxy.members.with({ team: 'blue' }).orderedBy(['joinedAt'])];
-      },
+      () => [getProxy.members.with({ team: 'blue' }).orderedBy(['joinedAt'])],
       {
         asyncContext: new AsyncLocalStorage(),
       },

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -94,7 +94,9 @@ describe('syntax proxy', () => {
     const queryList: Array<QueryItem> = [];
 
     getBatchProxy(
-      () => [getProxy.members.with({ team: 'blue' }).orderedBy(['joinedAt'])],
+      () => {
+        return [getProxy.members.with({ team: 'blue' }).orderedBy(['joinedAt'])];
+      },
       {
         asyncContext: new AsyncLocalStorage(),
       },

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -84,4 +84,38 @@ describe('syntax proxy', () => {
       },
     ]);
   });
+
+  test('using function chaining in batch', async () => {
+    const getQueryHandler = { callback: () => undefined };
+    const getQueryHandlerSpy = spyOn(getQueryHandler, 'callback');
+
+    const getProxy = getSyntaxProxy('get', getQueryHandlerSpy);
+
+    const queryList: Array<QueryItem> = [];
+
+    getBatchProxy(
+      () => [
+        getProxy.members.with({ team: 'blue' }).orderedBy(['joinedAt'])
+      ],
+      {
+        asyncContext: new AsyncLocalStorage(),
+      },
+      (queries) => queryList.push(...queries),
+    );
+
+    expect(queryList).toMatchObject([
+      {
+        query: {
+          get: {
+            members: {
+              with: {
+                team: 'blue',
+              },
+              orderedBy: ['joinedAt'],
+            },
+          },
+        }
+      },
+    ]);
+  });
 });

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -94,9 +94,7 @@ describe('syntax proxy', () => {
     const queryList: Array<QueryItem> = [];
 
     getBatchProxy(
-      () => [
-        getProxy.members.with({ team: 'blue' }).orderedBy(['joinedAt'])
-      ],
+      () => [getProxy.members.with({ team: 'blue' }).orderedBy(['joinedAt'])],
       {
         asyncContext: new AsyncLocalStorage(),
       },
@@ -114,7 +112,7 @@ describe('syntax proxy', () => {
               orderedBy: ['joinedAt'],
             },
           },
-        }
+        },
       },
     ]);
   });


### PR DESCRIPTION
This change makes it possible to chain function calls.

Subsequent calls are mounted to the same level as the original one, to keep the behavior predictable.

Example:

```typescript
import { get, batch } from 'ronin';

await batch(() => [
  get.members.with({ team: 'blue' }).orderedBy(['joinedAt']);
]);
```