### PR TITLE
Improved function chaining

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,23 +18,12 @@
     "prepare": "husky && bun run build",
     "format": "biome format --write"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "repository": "ronin-co/client",
   "homepage": "https://ronin.co/docs/typescript-client",
-  "keywords": [
-    "ronin",
-    "client",
-    "database",
-    "orm",
-    "edge",
-    "serverless"
-  ],
+  "keywords": ["ronin", "client", "database", "orm", "edge", "serverless"],
   "lint-staged": {
-    "**/*": [
-      "biome check"
-    ]
+    "**/*": ["biome check"]
   },
   "exports": {
     ".": {
@@ -56,18 +45,10 @@
   },
   "typesVersions": {
     "*": {
-      "*": [
-        "dist/index.d.ts"
-      ],
-      "types": [
-        "dist/types/index.d.ts"
-      ],
-      "schema": [
-        "dist/schema/index.d.ts"
-      ],
-      "utils": [
-        "dist/utils/index.d.ts"
-      ]
+      "*": ["dist/index.d.ts"],
+      "types": ["dist/types/index.d.ts"],
+      "schema": ["dist/schema/index.d.ts"],
+      "utils": ["dist/utils/index.d.ts"]
     }
   },
   "engines": {

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -169,5 +169,12 @@ export const getBatchProxy = <
     IN_BATCH_SYNC = false;
   }
 
-  return queriesHandler(queries) as PromiseTuple<T> | T;
+  // Within a batch, every query item is a JavaScript `Proxy`, in order to allow for
+  // function chaining within every query. Returning the query items directly would
+  // therefore return the respective `Proxy` instances, which wouldn't be logged as plain
+  // objects, thereby making development more difficult. To avoid this, we are creating a
+  // plain object containing the same properties as the `Proxy` instances.
+  const cleanQueries = queries.map((details) => ({ ...details }));
+
+  return queriesHandler(cleanQueries) as PromiseTuple<T> | T;
 };

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -139,5 +139,5 @@ export type ReplaceForSetter<TValue> = {
  */
 export interface QueryItem {
   query: Query;
-  options: Record<string, unknown>;
+  options?: Record<string, unknown>;
 }

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -67,7 +67,7 @@ describe('syntax proxy', () => {
       (queries) => queryList.push(...queries),
     );
 
-    expect(queryList).toMatchObject([
+    expect(queryList).toEqual([
       {
         query: {
           get: {
@@ -107,29 +107,34 @@ describe('syntax proxy', () => {
       (queries) => queryList.push(...queries),
     );
 
-    expect(queryList[0].query).toMatchObject({
-      get: {
-        members: {
-          with: {
-            team: 'red',
-          },
-          excluding: ['name'],
-        },
-      },
-    });
-
-    expect(queryList[1].query).toMatchObject({
-      get: {
-        members: {
-          with: {
-            team: 'blue',
-          },
-          orderedBy: {
-            ascending: ['joinedAt'],
+    expect(queryList).toEqual([
+      {
+        query: {
+          get: {
+            members: {
+              with: {
+                team: 'red',
+              },
+              excluding: ['name'],
+            },
           },
         },
       },
-    });
+      {
+        query: {
+          get: {
+            members: {
+              with: {
+                team: 'blue',
+              },
+              orderedBy: {
+                ascending: ['joinedAt'],
+              },
+            },
+          },
+        },
+      },
+    ]);
   });
 
   test('using schema query types', async () => {
@@ -164,59 +169,68 @@ describe('syntax proxy', () => {
       (queries) => queryList.push(...queries),
     );
 
-    expect(queryList[0].query).toMatchObject({
-      create: {
-        model: {
-          slug: 'account',
-        },
-      },
-    });
-
-    expect(queryList[1].query).toMatchObject({
-      alter: {
-        model: 'account',
-        to: {
-          slug: 'users',
-        },
-      },
-    });
-
-    expect(queryList[2].query).toMatchObject({
-      alter: {
-        model: 'users',
-        create: {
-          field: {
-            slug: 'handle',
+    expect(queryList).toEqual([
+      {
+        query: {
+          create: {
+            model: {
+              slug: 'account',
+            },
           },
         },
       },
-    });
-
-    expect(queryList[3].query).toMatchObject({
-      alter: {
-        model: 'users',
-        alter: {
-          field: 'handle',
-          to: {
-            name: 'User Handle',
+      {
+        query: {
+          alter: {
+            model: 'account',
+            to: {
+              slug: 'users',
+            },
           },
         },
       },
-    });
-
-    expect(queryList[4].query).toMatchObject({
-      alter: {
-        model: 'users',
-        drop: {
-          field: 'handle',
+      {
+        query: {
+          alter: {
+            create: {
+              field: {
+                slug: 'handle',
+              },
+            },
+            model: 'users',
+          },
         },
       },
-    });
-
-    expect(queryList[5].query).toMatchObject({
-      drop: {
-        model: 'users',
+      {
+        query: {
+          alter: {
+            alter: {
+              field: 'handle',
+              to: {
+                name: 'User Handle',
+              },
+            },
+            model: 'users',
+          },
+        },
       },
-    });
+      {
+        query: {
+          alter: {
+            drop: {
+              field: 'handle',
+            },
+            model: 'users',
+          },
+        },
+      },
+      {
+        query: {
+          drop: {
+            model: 'users',
+          },
+        },
+      },
+    ]);
   });
 });


### PR DESCRIPTION
This change improves https://github.com/ronin-co/client/pull/145 further by returning plain objects instead of `Proxy` instances from `getBatchProxy`, which makes development easier.