### PR TITLE
Automatically migrate package config

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -45,7 +45,8 @@
       "performance": {
         "all": true,
 
-        "noBarrelFile": "off"
+        "noBarrelFile": "off",
+        "noDelete": "off"
       },
       "security": { "all": true },
       "style": {

--- a/src/bin/utils/session.ts
+++ b/src/bin/utils/session.ts
@@ -74,7 +74,7 @@ export const storeTokenForNPM = async (token: string) => {
 
   // Remove the old registry config, since it causes a conflict with the `@ronin` scope
   // available on npm, which the RONIN team uses to publish packages.
-  npmConfigContents['@ronin:registry'] = undefined;
+  delete npmConfigContents['@ronin:registry'];
 
   await writeConfigFile(npmConfigFile, ini.stringify(npmConfigContents));
 };
@@ -94,7 +94,7 @@ export const storeTokenForBun = async (token: string) => {
 
   // Remove the old registry config, since it causes a conflict with the `@ronin` scope
   // available on npm, which the RONIN team uses to publish packages.
-  bunConfigContents.install.scopes.ronin = undefined;
+  delete bunConfigContents.install.scopes.ronin;
 
   await writeConfigFile(bunConfigFile, toml.stringify(bunConfigContents));
 };

--- a/src/bin/utils/session.ts
+++ b/src/bin/utils/session.ts
@@ -72,6 +72,10 @@ export const storeTokenForNPM = async (token: string) => {
   npmConfigContents['@ronin-types:registry'] = 'https://ronin.supply';
   npmConfigContents['//ronin.supply/:_authToken'] = token;
 
+  // Remove the old registry config, since it causes a conflict with the `@ronin` scope
+  // available on npm, which the RONIN team uses to publish packages.
+  npmConfigContents['@ronin:registry'] = undefined;
+
   await writeConfigFile(npmConfigFile, ini.stringify(npmConfigContents));
 };
 
@@ -87,6 +91,10 @@ export const storeTokenForBun = async (token: string) => {
 
   bunConfigContents.install.scopes['ronin-types'].url = 'https://ronin.supply';
   bunConfigContents.install.scopes['ronin-types'].token = token;
+
+  // Remove the old registry config, since it causes a conflict with the `@ronin` scope
+  // available on npm, which the RONIN team uses to publish packages.
+  bunConfigContents.install.scopes.ronin = undefined;
 
   await writeConfigFile(bunConfigFile, toml.stringify(bunConfigContents));
 };


### PR DESCRIPTION
This change automatically removes the `@ronin` scope from the `.npmrc` and `.bunfig.toml` config files!