### PR TITLE
Fixed fields with slug `name`

### DIFF
--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -33,7 +33,7 @@ import { mergeOptions } from '@/src/utils/helpers';
  *   },
  * });
  *
- * await add.account({ with: { email: 'mike@gmail.com' } });
+ * await add.account({ to: { email: 'mike@gmail.com' } });
  *
  * await remove.accounts.with.emailVerified.notBeing(true);
  *

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -60,6 +60,9 @@ export const getSyntaxProxy = (
     // we need to assign properties to the function itself.
     if (targetProps) Object.assign(proxyTargetFunction, targetProps);
 
+    // @ts-expect-error Deleting this property is required for fields called `name`.
+    delete proxyTargetFunction.name;
+
     return new Proxy(proxyTargetFunction, {
       apply(target: any, _thisArg: any, args: Array<any>) {
         let value = args[0];

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -16,12 +16,12 @@ describe('syntax proxy', () => {
     const getProxy = getSyntaxProxy('get', getQueryHandlerSpy);
     const addProxy = getSyntaxProxy('add', addQueryHandlerSpy);
 
-    addProxy.accounts.with(() => getProxy.oldAccounts());
+    addProxy.accounts.to(() => getProxy.oldAccounts());
 
     const finalQuery = {
       add: {
         accounts: {
-          with: {
+          to: {
             __RONIN_QUERY: {
               get: { oldAccounts: {} },
             },

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -34,6 +34,27 @@ describe('syntax proxy', () => {
     expect(addQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
   });
 
+  test('using expressions', async () => {
+    const setQueryHandler = { callback: () => undefined };
+    const setQueryHandlerSpy = spyOn(setQueryHandler, 'callback');
+
+    const setProxy = getSyntaxProxy('set', setQueryHandlerSpy);
+
+    setProxy.accounts.to.name('test');
+
+    const finalQuery = {
+      set: {
+        accounts: {
+          to: {
+            name: 'test',
+          },
+        },
+      },
+    };
+
+    expect(setQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
+  });
+
   test('using async context', async () => {
     const details = getBatchProxy(
       () => [get.account()],

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -34,25 +34,27 @@ describe('syntax proxy', () => {
     expect(addQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
   });
 
-  test('using expressions', async () => {
-    const setQueryHandler = { callback: () => undefined };
-    const setQueryHandlerSpy = spyOn(setQueryHandler, 'callback');
+  // Since `name` is a native property of functions and queries contain function calls,
+  // we have to explicitly assert whether it can be used as a field slug.
+  test('using field with slug `name`', async () => {
+    const getQueryHandler = { callback: () => undefined };
+    const getQueryHandlerSpy = spyOn(getQueryHandler, 'callback');
 
-    const setProxy = getSyntaxProxy('set', setQueryHandlerSpy);
+    const getProxy = getSyntaxProxy('get', getQueryHandlerSpy);
 
-    setProxy.accounts.to.name('test');
+    getProxy.accounts.with.name('test');
 
     const finalQuery = {
-      set: {
+      get: {
         accounts: {
-          to: {
+          with: {
             name: 'test',
           },
         },
       },
     };
 
-    expect(setQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
+    expect(getQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
   });
 
   test('using async context', async () => {


### PR DESCRIPTION
This change makes fields whose slug is `name` work.