### PR TITLE
Added support for basic expressions

### DIFF
--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -93,7 +93,7 @@ export const getSyntaxProxy = (
           if (instructions.query) {
             value = { [QUERY_SYMBOLS.QUERY]: instructions.query };
           } else {
-            value = instructions;
+            value = { [QUERY_SYMBOLS.EXPRESSION]: instructions };
           }
 
           IN_BATCH_SYNC = false;

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -214,10 +214,25 @@ type NestedObject = {
   [key: string]: unknown | NestedObject;
 };
 
+/**
+ * Checks whether a given value is a query expression.
+ *
+ * @param value - The value to check.
+ *
+ * @returns A boolean indicating whether or not the provided value is an expression.
+ */
 const isExpression = (value: unknown): boolean => {
   return typeof value === 'string' && value.includes(RONIN_EXPRESSION_SEPARATOR);
 };
 
+/**
+ * Wraps an expression string into a query symbol that allows the compiler to easily
+ * detect and process it.
+ *
+ * @param value - The expression to wrap.
+ *
+ * @returns The provided expression wrapped in a query symbol.
+ */
 const wrapExpression = (
   value: string,
 ): Record<typeof QUERY_SYMBOLS.EXPRESSION, string> => {
@@ -232,6 +247,14 @@ const wrapExpression = (
   return { [QUERY_SYMBOLS.EXPRESSION]: components };
 };
 
+/**
+ * Recursively checks an object for query expressions and, if they are found, wraps them
+ * in a query symbol that allows the compiler to easily detect and process them.
+ *
+ * @param obj - The object containing potential expressions.
+ *
+ * @returns The updated object.
+ */
 const wrapExpressions = (obj: NestedObject): NestedObject =>
   Object.fromEntries(
     Object.entries(obj).map(([key, value]) => {

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -1,6 +1,7 @@
 import type { AsyncLocalStorage } from 'node:async_hooks';
 
 import type { PromiseTuple, QueryHandlerOptions, QueryItem } from '@/src/types/utils';
+import { RONIN_EXPRESSION_SEPARATOR } from '@/src/utils/constants';
 import { setProperty } from '@/src/utils/helpers';
 import { QUERY_SYMBOLS, type Query } from '@ronin/compiler';
 
@@ -78,22 +79,33 @@ export const getSyntaxProxy = (
           // which avoids the need to pass it as an option to the client.
           IN_BATCH_SYNC = true;
 
-          const instructions = value(
-            new Proxy(
-              {},
-              {
-                get(_target, property) {
-                  const propertyName = property.toString();
-                  return `${QUERY_SYMBOLS.FIELD}${propertyName}`;
-                },
+          // A proxy object providing a property for every field of the model. It allows
+          // for referencing fields inside of an expression.
+          const fieldProxy = new Proxy(
+            {},
+            {
+              get(_target, property) {
+                const propertyName = property.toString();
+                return `${RONIN_EXPRESSION_SEPARATOR}${QUERY_SYMBOLS.FIELD}${propertyName}${RONIN_EXPRESSION_SEPARATOR}`;
               },
-            ),
+            },
           );
+
+          const instructions = value(fieldProxy);
 
           if (instructions.query) {
             value = { [QUERY_SYMBOLS.QUERY]: instructions.query };
-          } else {
-            value = { [QUERY_SYMBOLS.EXPRESSION]: instructions };
+          } else if (typeof instructions === 'string') {
+            const components = instructions
+              .split(RONIN_EXPRESSION_SEPARATOR)
+              .filter((part) => part.length > 0)
+              .map((part) => {
+                return part.startsWith(QUERY_SYMBOLS.FIELD) ? part : `'${part}'`;
+              });
+
+            value = {
+              [QUERY_SYMBOLS.EXPRESSION]: components.join(' || '),
+            };
           }
 
           IN_BATCH_SYNC = false;

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -97,20 +97,14 @@ export const getSyntaxProxy = (
 
           if (instructions.query) {
             value = { [QUERY_SYMBOLS.QUERY]: instructions.query };
-          } else if (typeof instructions === 'string') {
-            const components = instructions
-              .split(RONIN_EXPRESSION_SEPARATOR)
-              .filter((part) => part.length > 0)
-              .map((part) => {
-                return part.startsWith(QUERY_SYMBOLS.FIELD) ? part : `'${part}'`;
-              })
-              .join(' || ');
+          } else {
+            value = instructions;
+          }
 
-            value = {
-              [QUERY_SYMBOLS.EXPRESSION]: components,
-            };
-          } else if (typeof instructions === 'object') {
-            value = wrapExpressions(instructions);
+          if (isExpression(value)) {
+            value = wrapExpression(value as string);
+          } else if (typeof value === 'object') {
+            value = wrapExpressions(value);
           }
 
           IN_BATCH_SYNC = false;
@@ -220,20 +214,28 @@ type NestedObject = {
   [key: string]: unknown | NestedObject;
 };
 
+const isExpression = (value: unknown): boolean => {
+  return typeof value === 'string' && value.includes(RONIN_EXPRESSION_SEPARATOR);
+};
+
+const wrapExpression = (
+  value: string,
+): Record<typeof QUERY_SYMBOLS.EXPRESSION, string> => {
+  const components = value
+    .split(RONIN_EXPRESSION_SEPARATOR)
+    .filter((part) => part.length > 0)
+    .map((part) => {
+      return part.startsWith(QUERY_SYMBOLS.FIELD) ? part : `'${part}'`;
+    })
+    .join(' || ');
+
+  return { [QUERY_SYMBOLS.EXPRESSION]: components };
+};
+
 const wrapExpressions = (obj: NestedObject): NestedObject =>
   Object.fromEntries(
     Object.entries(obj).map(([key, value]) => {
-      if (typeof value === 'string' && value.includes(RONIN_EXPRESSION_SEPARATOR)) {
-        const components = value
-          .split(RONIN_EXPRESSION_SEPARATOR)
-          .filter((part) => part.length > 0)
-          .map((part) => {
-            return part.startsWith(QUERY_SYMBOLS.FIELD) ? part : `'${part}'`;
-          })
-          .join(' || ');
-
-        return [key, { [QUERY_SYMBOLS.EXPRESSION]: components }];
-      }
+      if (isExpression(value)) return [key, wrapExpression(value as string)];
 
       return [
         key,

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -77,7 +77,25 @@ export const getSyntaxProxy = (
           // an asynchronous function, so we don't need to use `IN_BATCH_ASYNC`,
           // which avoids the need to pass it as an option to the client.
           IN_BATCH_SYNC = true;
-          value = { [QUERY_SYMBOLS.QUERY]: value().query };
+
+          const instructions = value(
+            new Proxy(
+              {},
+              {
+                get(_target, property) {
+                  const propertyName = property.toString();
+                  return `${QUERY_SYMBOLS.FIELD}${propertyName}`;
+                },
+              },
+            ),
+          );
+
+          if (instructions.query) {
+            value = { [QUERY_SYMBOLS.QUERY]: instructions.query };
+          } else {
+            value = instructions;
+          }
+
           IN_BATCH_SYNC = false;
         }
 

--- a/src/syntax/utils.ts
+++ b/src/syntax/utils.ts
@@ -85,8 +85,10 @@ export const getSyntaxProxy = (
             {},
             {
               get(_target, property) {
-                const propertyName = property.toString();
-                return `${RONIN_EXPRESSION_SEPARATOR}${QUERY_SYMBOLS.FIELD}${propertyName}${RONIN_EXPRESSION_SEPARATOR}`;
+                const name = property.toString();
+                const split = RONIN_EXPRESSION_SEPARATOR;
+
+                return `${split}${QUERY_SYMBOLS.FIELD}${name}${split}`;
               },
             },
           );
@@ -101,11 +103,14 @@ export const getSyntaxProxy = (
               .filter((part) => part.length > 0)
               .map((part) => {
                 return part.startsWith(QUERY_SYMBOLS.FIELD) ? part : `'${part}'`;
-              });
+              })
+              .join(' || ');
 
             value = {
-              [QUERY_SYMBOLS.EXPRESSION]: components.join(' || '),
+              [QUERY_SYMBOLS.EXPRESSION]: components,
             };
+          } else if (typeof instructions === 'object') {
+            value = wrapExpressions(instructions);
           }
 
           IN_BATCH_SYNC = false;
@@ -210,3 +215,31 @@ export const getBatchProxy = <
 
   return queriesHandler(cleanQueries) as PromiseTuple<T> | T;
 };
+
+type NestedObject = {
+  [key: string]: unknown | NestedObject;
+};
+
+const wrapExpressions = (obj: NestedObject): NestedObject =>
+  Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => {
+      if (typeof value === 'string' && value.includes(RONIN_EXPRESSION_SEPARATOR)) {
+        const components = value
+          .split(RONIN_EXPRESSION_SEPARATOR)
+          .filter((part) => part.length > 0)
+          .map((part) => {
+            return part.startsWith(QUERY_SYMBOLS.FIELD) ? part : `'${part}'`;
+          })
+          .join(' || ');
+
+        return [key, { [QUERY_SYMBOLS.EXPRESSION]: components }];
+      }
+
+      return [
+        key,
+        value && typeof value === 'object'
+          ? wrapExpressions(value as NestedObject)
+          : value,
+      ];
+    }),
+  );

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,5 @@
 /** A list of all query types that update the database. */
 export const WRITE_QUERY_TYPES = ['add', 'set', 'remove', 'create', 'alter', 'drop'];
+
+/** Used to separate the components of an expression from each other. */
+export const RONIN_EXPRESSION_SEPARATOR = '//.//';

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -47,7 +47,9 @@ describe('syntax proxy', () => {
       set: {
         accounts: {
           to: {
-            name: `${QUERY_SYMBOLS.FIELD}oldName`,
+            name: {
+              [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD}oldName`,
+            },
           },
         },
       },

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -41,7 +41,7 @@ describe('syntax proxy', () => {
 
     const setProxy = getSyntaxProxy('set', setQueryHandlerSpy);
 
-    setProxy.accounts.to.name((f) => `${f.firstName} || ' ' || ${f.lastName}`);
+    setProxy.accounts.to.name((f) => `${f.firstName} ${f.lastName}`);
 
     const finalQuery = {
       set: {

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -39,16 +39,16 @@ describe('syntax proxy', () => {
     const setQueryHandler = { callback: () => undefined };
     const setQueryHandlerSpy = spyOn(setQueryHandler, 'callback');
 
-    const setPropxy = getSyntaxProxy('set', setQueryHandlerSpy);
+    const setProxy = getSyntaxProxy('set', setQueryHandlerSpy);
 
-    setPropxy.accounts.to.name((f) => f.oldName);
+    setProxy.accounts.to.name((f) => `${f.firstName} || ' ' || ${f.lastName}`);
 
     const finalQuery = {
       set: {
         accounts: {
           to: {
             name: {
-              [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD}oldName`,
+              [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD}firstName || ' ' || ${QUERY_SYMBOLS.FIELD}lastName`,
             },
           },
         },

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, spyOn, test } from 'bun:test';
 import { get } from '@/src/index';
 import type { QueryItem } from '@/src/types/utils';
 import { getBatchProxy, getSyntaxProxy } from '@/src/utils';
+import { QUERY_SYMBOLS } from '@ronin/compiler';
 
 describe('syntax proxy', () => {
   test('using sub query', async () => {
@@ -32,6 +33,27 @@ describe('syntax proxy', () => {
 
     expect(getQueryHandlerSpy).not.toHaveBeenCalled();
     expect(addQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
+  });
+
+  test('using field with expression', async () => {
+    const setQueryHandler = { callback: () => undefined };
+    const setQueryHandlerSpy = spyOn(setQueryHandler, 'callback');
+
+    const setPropxy = getSyntaxProxy('set', setQueryHandlerSpy);
+
+    setPropxy.accounts.to.name((f) => f.oldName);
+
+    const finalQuery = {
+      set: {
+        accounts: {
+          to: {
+            name: `${QUERY_SYMBOLS.FIELD}oldName`,
+          },
+        },
+      },
+    };
+
+    expect(setQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
   });
 
   // Since `name` is a native property of functions and queries contain function calls,

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -81,6 +81,35 @@ describe('syntax proxy', () => {
     expect(getQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
   });
 
+  test('using multiple fields with expressions', async () => {
+    const setQueryHandler = { callback: () => undefined };
+    const setQueryHandlerSpy = spyOn(setQueryHandler, 'callback');
+
+    const setProxy = getSyntaxProxy('set', setQueryHandlerSpy);
+
+    setProxy.accounts.to((f) => ({
+      name: `${f.firstName} ${f.lastName}`,
+      email: `${f.handle}@site.co`,
+    }));
+
+    const finalQuery = {
+      set: {
+        accounts: {
+          to: {
+            name: {
+              [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD}firstName || ' ' || ${QUERY_SYMBOLS.FIELD}lastName`,
+            },
+            email: {
+              [QUERY_SYMBOLS.EXPRESSION]: `${QUERY_SYMBOLS.FIELD}handle || '@site.co'`,
+            },
+          },
+        },
+      },
+    };
+
+    expect(setQueryHandlerSpy).toHaveBeenCalledWith(finalQuery, undefined);
+  });
+
   test('using async context', async () => {
     const details = getBatchProxy(
       () => [get.account()],

--- a/tests/unit/proxies.test.ts
+++ b/tests/unit/proxies.test.ts
@@ -41,7 +41,9 @@ describe('syntax proxy', () => {
 
     const setProxy = getSyntaxProxy('set', setQueryHandlerSpy);
 
-    setProxy.accounts.to.name((f) => `${f.firstName} ${f.lastName}`);
+    setProxy.accounts.to.name(
+      (f: Record<string, unknown>) => `${f.firstName} ${f.lastName}`,
+    );
 
     const finalQuery = {
       set: {
@@ -87,7 +89,7 @@ describe('syntax proxy', () => {
 
     const setProxy = getSyntaxProxy('set', setQueryHandlerSpy);
 
-    setProxy.accounts.to((f) => ({
+    setProxy.accounts.to((f: Record<string, unknown>) => ({
       name: `${f.firstName} ${f.lastName}`,
       email: `${f.handle}@site.co`,
     }));


### PR DESCRIPTION
This change allows for adding simple expressions to RONIN queries, such as the following:

```typescript
import { set } from 'ronin';

set.accounts.to.name((f) => `${f.firstName} ${f.lastName}`);
```

The query above sets the `name` field of all account records to a concatenated string containing both the value of the `firstName` field and the value of the `lastName` field.

For now, expressions will only be possible to use when referencing fields, such as in the example above. Use cases where expressions do not rely on the value of a field (such as `20 + 20`) should be computed ahead of time, to avoid an unnecessary impact on performance. For that, people can write arbitrary TypeScript within the query, which is inherently naturally executed at compilation time:

```typescript
import { set } from 'ronin';

set.accounts.to.age(20 + 20);
```