### PR TITLE
Ensure that `models` are optional

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -89,7 +89,7 @@ export const runQueries = async <T>(
   // Runtimes like Cloudflare Workers don't support `cache` yet.
   const hasCachingSupport = 'cache' in new Request('https://ronin.co');
 
-  const request = new Request('https://data.ronin.co/', {
+  const request = new Request('https://data.ronin.co/?latest=true', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
With this change, it is no longer necessary to pass a `models` option to the client. Instead, the queries will function in the same way as before, even without the option being passed.