### PR TITLE
Directly export `batch` method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,4 +141,11 @@ export const alter = factory.alter as DeepCallable<
 >;
 export const drop = factory.drop as DeepCallable<DropQuery, Model>;
 
+export const batch = factory.batch as <
+  T extends [Promise<any>, ...Array<Promise<any>>] | Array<Promise<any>>,
+>(
+  operations: () => T,
+  queryOptions?: Record<string, unknown>,
+) => Promise<PromiseTuple<T>>;
+
 export default createSyntaxFactory;


### PR DESCRIPTION
This change ensures that the client exports the `batch` method, which is used for batching up multiple queries into a single database transaction.