### PR TITLE
Allow for providing raw SQL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,10 +127,24 @@ export const createSyntaxFactory = (
     },
 
     sql: (strings: TemplateStringsArray, ...values: Array<unknown>) => {
-      console.log('STRING:', strings);
-      console.log('VALUES:', values);
+      let text = '';
+      const params: Array<unknown> = [];
 
-      return 'test';
+      strings.forEach((string, i) => {
+        text += string;
+
+        if (i < values.length) {
+          text += `$${i + 1}`;
+          params.push(values[i]);
+        }
+      });
+
+      const statement = {
+        statement: text,
+        params,
+      };
+
+      return queryHandler({ statement }, mergeOptions(options, {}));
     },
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,8 @@ export const createSyntaxFactory = (
     operations: () => T,
     queryOptions?: Record<string, unknown>,
   ) => Promise<PromiseTuple<T>>;
+
+  sql: (strings: TemplateStringsArray, ...values: Array<unknown>) => unknown;
 } => {
   const callback = (query: Query, queryOptions?: QueryHandlerOptions) =>
     queryHandler(query, mergeOptions(options, queryOptions));
@@ -122,6 +124,13 @@ export const createSyntaxFactory = (
       const finalOptions = mergeOptions(options, queryOptions);
 
       return queriesHandler(queries, finalOptions) as Promise<PromiseTuple<T>>;
+    },
+
+    sql: (strings: TemplateStringsArray, ...values: Array<unknown>) => {
+      console.log('STRING:', strings);
+      console.log('VALUES:', values);
+
+      return 'test';
     },
   };
 };

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -344,7 +344,7 @@ const invokeHooks = async (
  * @returns The results of the queries that were passed.
  */
 export const runQueriesWithHooks = async <T>(
-  queries: Query[],
+  queries: Array<Query>,
   options: QueryHandlerOptions = {},
 ): Promise<Results<T>> => {
   const { hooks, waitUntil, asyncContext } = options;

--- a/tests/integration/sql.test.ts
+++ b/tests/integration/sql.test.ts
@@ -1,0 +1,26 @@
+import { expect, mock, test } from 'bun:test';
+import createSyntaxFactory from '@/src/index';
+
+test('run SQL statements', async () => {
+  let mockRequestResolvedValue: Request | undefined;
+
+  const mockFetchNew = mock((request) => {
+    mockRequestResolvedValue = request;
+
+    return Response.json({
+      results: [],
+    });
+  });
+
+  const factory = createSyntaxFactory({
+    fetch: async (request) => mockFetchNew(request),
+    token: 'takashitoken',
+  });
+
+  await factory.sql`SELECT * FROM accounts`;
+
+  expect(mockFetchNew).toHaveBeenCalledTimes(1);
+  expect(await mockRequestResolvedValue?.text()).toEqual(
+    '{"queries":[{"count":{"spaces":{"with":{"membersCount":{"greaterThan":10}}}}}]}',
+  );
+});

--- a/tests/integration/sql.test.ts
+++ b/tests/integration/sql.test.ts
@@ -17,10 +17,11 @@ test('run SQL statements', async () => {
     token: 'takashitoken',
   });
 
-  await factory.sql`SELECT * FROM accounts`;
+  const accountHandle = 'elaine';
+  await factory.sql`SELECT * FROM accounts WHERE handle = ${accountHandle} AND active = true AND name = ${'dsaads'}`;
 
   expect(mockFetchNew).toHaveBeenCalledTimes(1);
   expect(await mockRequestResolvedValue?.text()).toEqual(
-    '{"queries":[{"count":{"spaces":{"with":{"membersCount":{"greaterThan":10}}}}}]}',
+    '{"nativeQueries":[{"query":"SELECT * FROM accounts WHERE handle = $1 AND active = true AND name = $2","values":["elaine","dsaads"]}]}',
   );
 });

--- a/tests/unit/queries.test.ts
+++ b/tests/unit/queries.test.ts
@@ -26,7 +26,7 @@ describe('queries handler', () => {
 
     import.meta.env.RONIN_TOKEN = undefined;
 
-    expect(queriesHandler([], {})).rejects.toThrow(
+    expect(queriesHandler.bind([], {})).toThrow(
       'Please specify the `RONIN_TOKEN` environment variable or set the `token` option when invoking RONIN.',
     );
 
@@ -155,7 +155,8 @@ describe('queries handler', () => {
   });
 
   test('enable verbose logging', async () => {
-    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    const currentConsoleLog = console.log;
+    const logSpy = spyOn(console, 'log').mockImplementation(currentConsoleLog);
 
     await queriesHandler([]);
 


### PR DESCRIPTION
In addition to RONIN queries, the client now accepts raw SQL statements like so:

```
import { sql } from 'ronin';

const accountHandle = 'elaine';
const records = await sql`SELECT * FROM accounts WHERE handle = ${accountHandle}`;
```

The parameters in the SQL statements are automatically separated, in order to avoid SQL injections.