### PR TITLE
Correctly format fields

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.2.36",
-        "@ronin/compiler": "0.16.2",
+        "@ronin/compiler": "0.16.4",
         "@ronin/syntax": "0.2.17",
       },
       "devDependencies": {
@@ -173,7 +173,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.2.36", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-U7aCN2S7GQiO/ef8RSxRLdRX13xJxoCEEyEEwwR4R4csZXsuUR1GEK97SA9nOHYVJi+9JA3gQm76y2d80q3Wfw=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.16.2", "", {}, "sha512-2j862j2FZCb3JkoH7XgvthywK1VwVGCCjOqgWKJanyjOfdfg37NTgiFhdKiA2C5DqICTkf7C7JJgw50gj8BB3Q=="],
+    "@ronin/compiler": ["@ronin/compiler@0.16.4", "", {}, "sha512-eCWc1wi4tC3KWvT5rTlKjJvw5YQ5qdQ9+Sz1ysYZDLDFiMBD5+/wCg2s5wZEABD/Tm1rk0cJCwni4C2yMahHug=="],
 
     "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ronin/cli": "0.2.36",
-    "@ronin/compiler": "0.16.2",
+    "@ronin/compiler": "0.16.4",
     "@ronin/syntax": "0.2.17"
   },
   "devDependencies": {

--- a/tests/unit/queries.test.ts
+++ b/tests/unit/queries.test.ts
@@ -153,7 +153,6 @@ describe('queries handler', () => {
             records: [
               {
                 id: 'acc_39h8fhe98hefah8j',
-                'ronin.locked': null,
                 'ronin.createdAt': '2021-09-29T14:00:00.000Z',
                 'ronin.createdBy': null,
                 'ronin.updatedAt': '2021-09-29T14:00:00.000Z',
@@ -208,7 +207,6 @@ describe('queries handler', () => {
         id: 'acc_39h8fhe98hefah8j',
         handle: 'markus',
         ronin: {
-          locked: false,
           createdAt: expect.any(Date),
           createdBy: null,
           updatedAt: expect.any(Date),


### PR DESCRIPTION
This change ensures that empty boolean fields are formatted as `null` instead of `false`.

Originally, the change was applied in https://github.com/ronin-co/compiler/pull/140.

---

Furthermore:

The `ronin.locked` field is no longer needed, so we are removing it!

Originally, the change was applied in https://github.com/ronin-co/compiler/pull/139.

---

Furthermore:

Previously, when retrieving records, empty fields were asserted using `= NULL`, which is not valid in SQLite.

Instead, we are now correctly using `IS NULL`.

Originally, the change was applied in https://github.com/ronin-co/compiler/pull/138.

---

Furthermore:

This change ensures that statement parameters are correctly inlined when the `inlineParams` config option is used.

Previously, booleans and integers were incorrectly inlined as strings, for example.

Originally, the change was applied in https://github.com/ronin-co/compiler/pull/137.