### PR TITLE
Correctly sort migrations in `apply` prompt

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "ronin",
       "dependencies": {
-        "@ronin/cli": "0.2.36",
+        "@ronin/cli": "0.2.37",
         "@ronin/compiler": "0.17.0",
         "@ronin/syntax": "0.2.17",
       },
@@ -171,7 +171,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.34.6", "", { "os": "win32", "cpu": "x64" }, "sha512-0PVwmgzZ8+TZ9oGBmdZoQVXflbvuwzN/HRclujpl4N/q3i+y0lqLw8n1bXA8ru3sApDjlmONaNAuYr38y1Kr9w=="],
 
-    "@ronin/cli": ["@ronin/cli@0.2.36", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-U7aCN2S7GQiO/ef8RSxRLdRX13xJxoCEEyEEwwR4R4csZXsuUR1GEK97SA9nOHYVJi+9JA3gQm76y2d80q3Wfw=="],
+    "@ronin/cli": ["@ronin/cli@0.2.37", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-kBLpbywHT+z32z4xIlEjT8rLrjOBkLUQO/yVeLJkWXPwf/CdKARX156J/qtALascw6eukk/dJAasrnhS2Qcsww=="],
 
     "@ronin/compiler": ["@ronin/compiler@0.17.0", "", {}, "sha512-LfQMPU57pc0ITUqiTnPnhAEP3QjLPfAFPmvIrHP1DTx9/7LqGhKKv2x84UjbV06Av2+1v1riWEWjN+hPuAA+Rw=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "author": "ronin",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ronin/cli": "0.2.36",
+    "@ronin/cli": "0.2.37",
     "@ronin/compiler": "0.17.0",
     "@ronin/syntax": "0.2.17"
   },


### PR DESCRIPTION
When executing `ronin apply`, users are prompted to select the desired migration to run, with migrations sorted by default. The latest migrations are displayed first. Additionally, the query syntax has been updated, replacing `including` with `using` in https://github.com/ronin-co/compiler/pull/127.

This change was originally landed in https://github.com/ronin-co/cli/pull/52.