### PR TITLE
Updated `package.json` property ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
     }
   },
   "scripts": {
-    "dev": "tsup --watch",
-    "build": "tsup",
-    "test": "bun test",
     "lint": "bun run --bun lint:tsc && bun run --bun lint:biome",
     "lint:biome": "biome check",
     "lint:tsc": "tsc --pretty",
-    "prepare": "bun run build",
-    "format": "biome format --write"
+    "format": "biome format --write",
+    "test": "bun test",
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "prepare": "bun run build"
   },
   "keywords": [
     "ronin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ronin",
-  "version": "6.2.5",
+  "version": "6.2.6",
   "type": "module",
   "description": "Access your RONIN database via TypeScript.",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ronin",
-  "version": "6.2.6",
+  "version": "6.2.5",
   "type": "module",
   "description": "Access your RONIN database via TypeScript.",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -12,26 +12,6 @@
   "files": [
     "dist"
   ],
-  "scripts": {
-    "dev": "bun run build -- --watch",
-    "build": "tsup",
-    "test": "bun test",
-    "lint": "bun run --bun lint:tsc && bun run --bun lint:biome",
-    "lint:biome": "biome check",
-    "lint:tsc": "tsc --pretty",
-    "prepare": "bun run build",
-    "format": "biome format --write"
-  },
-  "repository": "ronin-co/client",
-  "homepage": "https://ronin.co/docs/typescript-client",
-  "keywords": [
-    "ronin",
-    "client",
-    "database",
-    "orm",
-    "edge",
-    "serverless"
-  ],
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -66,11 +46,31 @@
       ]
     }
   },
+  "scripts": {
+    "dev": "tsup --watch",
+    "build": "tsup",
+    "test": "bun test",
+    "lint": "bun run --bun lint:tsc && bun run --bun lint:biome",
+    "lint:biome": "biome check",
+    "lint:tsc": "tsc --pretty",
+    "prepare": "bun run build",
+    "format": "biome format --write"
+  },
+  "keywords": [
+    "ronin",
+    "client",
+    "database",
+    "orm",
+    "edge",
+    "serverless"
+  ],
+  "author": "ronin",
+  "license": "Apache-2.0",
+  "repository": "ronin-co/client",
+  "homepage": "https://ronin.co/docs/typescript-client",
   "engines": {
     "node": ">=18.17.0"
   },
-  "author": "ronin",
-  "license": "Apache-2.0",
   "dependencies": {
     "@ronin/cli": "0.2.36",
     "@ronin/compiler": "0.16.4",


### PR DESCRIPTION
This PR updates the ordering of the properties in the `package.json` file to match* our other existing repositories. This way there is a consistent pattern across all repositories. This additionally updates the `dev` script to match [the `@ronin/syntax` package](https://github.com/ronin-co/syntax/blob/main/package.json#L33).

*Some properties exist here that don't exist in other RONIN packages & so some additional re-ordering was needed.