### PR TITLE
Prevent crash if batch contains empty values

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "dependencies": {
         "@ronin/cli": "0.2.37",
         "@ronin/compiler": "0.17.0",
-        "@ronin/syntax": "0.2.19",
+        "@ronin/syntax": "0.2.20",
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -177,7 +177,7 @@
 
     "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 
-    "@ronin/syntax": ["@ronin/syntax@0.2.19", "", {}, "sha512-kbONDqLldIEzoTgXevF7MhXVbqkeRZ8xANiqFtSaCnXkyrWb68ohBVin/QAk+GqQ0ZllMmbqrpezohm5vK829g=="],
+    "@ronin/syntax": ["@ronin/syntax@0.2.20", "", {}, "sha512-Ty/kj/ZKJ4/DE3LPOhlXLQyVnRSZ966P0cxO0zc4eBB3TtidpKmjjIINNlf64LsSwopgdtPnbxEJOKP6gaKzNg=="],
 
     "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@ronin/cli": "0.2.37",
     "@ronin/compiler": "0.17.0",
-    "@ronin/syntax": "0.2.19"
+    "@ronin/syntax": "0.2.20"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
It is perfectly normal to place a value such as `null` inside a batch, because that makes it easy to construct batches with multiple queries, where each one is constructed using a ternary. Without placeholders like those, all the values after it would of course shift one array index upward, which is not an option.

The latest syntax no longer supports these kinds of values, so I'm adding back support for them.

Originally, this change was landed in https://github.com/ronin-co/syntax/pull/50.