### PR TITLE
Bumped `@ronin/syntax` version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "dependencies": {
         "@ronin/cli": "0.2.37",
         "@ronin/compiler": "0.17.0",
-        "@ronin/syntax": "0.2.20",
+        "@ronin/syntax": "0.2.21",
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -177,7 +177,7 @@
 
     "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 
-    "@ronin/syntax": ["@ronin/syntax@0.2.20", "", {}, "sha512-Ty/kj/ZKJ4/DE3LPOhlXLQyVnRSZ966P0cxO0zc4eBB3TtidpKmjjIINNlf64LsSwopgdtPnbxEJOKP6gaKzNg=="],
+    "@ronin/syntax": ["@ronin/syntax@0.2.21", "", {}, "sha512-RGysrzUN+pNgZzWTHHjjyGqdhZAh93zC4LOnV1oJ11NdOUlcUll9qji+R2NOyz3DPBhbd/7h8Fq9QHX+zdORPA=="],
 
     "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@ronin/cli": "0.2.37",
     "@ronin/compiler": "0.17.0",
-    "@ronin/syntax": "0.2.20"
+    "@ronin/syntax": "0.2.21"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
This is a small & simple PR to upgrade the `@ronin/syntax` dependency version to use the latest available version. Which at this time is currently `0.2.21`.