### PR TITLE
Export util for parsing blob objects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,9 +103,8 @@ export const createSyntaxFactory = (
     return queryHandler(query[QUERY_SYMBOLS.QUERY], mergeOptions(options, queryOptions));
   };
 
-  const replacer = (value: unknown) => {
-    return isStorableObject(value) ? value : JSON.parse(JSON.stringify(value));
-  };
+  // Ensure that storable objects are retained as-is instead of being serialized.
+  const replacer = (value: unknown) => (isStorableObject(value) ? value : undefined);
 
   return {
     // Query types for interacting with records.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,3 @@
 export { runQueriesWithStorageAndHooks as runQueries } from '@/src/queries';
-export { processStorableObjects } from '@/src/storage';
+export { processStorableObjects, isStorableObject } from '@/src/storage';
 export { InvalidResponseError } from '@/src/utils/errors';


### PR DESCRIPTION
This change ensures that the client exports are utility function used for finding blob objects in a query.