### PR TITLE
Allow to process fields, indexes and triggers as objects

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "ronin",
       "dependencies": {
-        "@ronin/cli": "0.2.37",
+        "@ronin/cli": "0.2.38",
         "@ronin/compiler": "0.17.6",
         "@ronin/syntax": "0.2.28",
       },
@@ -171,7 +171,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.34.8", "", { "os": "win32", "cpu": "x64" }, "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g=="],
 
-    "@ronin/cli": ["@ronin/cli@0.2.37", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-kBLpbywHT+z32z4xIlEjT8rLrjOBkLUQO/yVeLJkWXPwf/CdKARX156J/qtALascw6eukk/dJAasrnhS2Qcsww=="],
+    "@ronin/cli": ["@ronin/cli@0.2.38", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-xAnz3Uxr9sg8XiRQ42egpmJg1D8Tqrha84uZzNLCxI7jalyKiVvKSL3WVf/oJnAHP0o/vRSHITgNneCeZO2gIg=="],
 
     "@ronin/compiler": ["@ronin/compiler@0.17.6", "", {}, "sha512-ob2bPsYkPQK8sN6zYCcbZQ1oBXOJn6suy145yufz3dpjFgdYSvvncsQwJASL15tMVx4AadcXy5WYpNlp/SJerA=="],
 
@@ -371,7 +371,7 @@
 
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
-    "tinyglobby": ["tinyglobby@0.2.11", "", { "dependencies": { "fdir": "^6.4.3", "picomatch": "^4.0.2" } }, "sha512-32TmKeeKUahv0Go8WmQgiEp9Y21NuxjwjqiRC1nrUB51YacfSwuB44xgXD+HdIppmMRgjQNPdrHyA6vIybYZ+g=="],
+    "tinyglobby": ["tinyglobby@0.2.12", "", { "dependencies": { "fdir": "^6.4.3", "picomatch": "^4.0.2" } }, "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww=="],
 
     "tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "~1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "node": ">=18.17.0"
   },
   "dependencies": {
-    "@ronin/cli": "0.2.37",
+    "@ronin/cli": "0.2.38",
     "@ronin/compiler": "0.17.6",
     "@ronin/syntax": "0.2.28"
   },


### PR DESCRIPTION
The CLI is now able to handle object representations of fields, indexes, and triggers. However, there are still some type errors and too many instances where arrays are used instead of objects and vice versa.

This was landed in https://github.com/ronin-co/cli/pull/56.