### PR TITLE
Correctly parse remote models when applying migrations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,8 +4,8 @@
     "": {
       "name": "ronin",
       "dependencies": {
-        "@ronin/cli": "0.2.38",
-        "@ronin/compiler": "0.17.6",
+        "@ronin/cli": "0.2.39",
+        "@ronin/compiler": "0.17.7",
         "@ronin/syntax": "0.2.28",
       },
       "devDependencies": {
@@ -171,9 +171,9 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.34.8", "", { "os": "win32", "cpu": "x64" }, "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g=="],
 
-    "@ronin/cli": ["@ronin/cli@0.2.38", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-xAnz3Uxr9sg8XiRQ42egpmJg1D8Tqrha84uZzNLCxI7jalyKiVvKSL3WVf/oJnAHP0o/vRSHITgNneCeZO2gIg=="],
+    "@ronin/cli": ["@ronin/cli@0.2.39", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-r3yEBOCuVyTXOPouJKC/LWLByXE73TJo5bSFsYIDN04lKxBvCjrzGAfFJ8tMVdEeeBxz4slhoQkbWIxmysWuIQ=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.6", "", {}, "sha512-ob2bPsYkPQK8sN6zYCcbZQ1oBXOJn6suy145yufz3dpjFgdYSvvncsQwJASL15tMVx4AadcXy5WYpNlp/SJerA=="],
+    "@ronin/compiler": ["@ronin/compiler@0.17.7", "", {}, "sha512-r4Jykn1YzGRCZglO8cxtmT8BnUH90vB5Cr8bjG5DcQNp5djImhe+ClXlzMAz89G3oZ6F2WGaSyOB5FAeiFPIsQ=="],
 
     "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "node": ">=18.17.0"
   },
   "dependencies": {
-    "@ronin/cli": "0.2.38",
-    "@ronin/compiler": "0.17.6",
+    "@ronin/cli": "0.2.39",
+    "@ronin/compiler": "0.17.7",
     "@ronin/syntax": "0.2.28"
   },
   "devDependencies": {


### PR DESCRIPTION
When executing `ronin apply`, the CLI provides the existing models to the compiler. This pull request addresses a bug where models were incorrectly passed with fields as arrays instead of objects.

This was landed in https://github.com/ronin-co/cli/pull/57.
