### PR TITLE
Automatically strip out any comments in SQL templates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "dependencies": {
         "@ronin/cli": "0.2.39",
         "@ronin/compiler": "0.17.7",
-        "@ronin/syntax": "0.2.29",
+        "@ronin/syntax": "0.2.30",
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -177,7 +177,7 @@
 
     "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 
-    "@ronin/syntax": ["@ronin/syntax@0.2.29", "", {}, "sha512-D2fA5GZfA6FoZ3M741OkNiiT7axADidK/TdD0hXFHYtsJFB9l3IN7r2sRoTMI/GvwWC0XXX+F6V+EGltGxVtkA=="],
+    "@ronin/syntax": ["@ronin/syntax@0.2.30", "", {}, "sha512-bWddS4r6Zj/H3IZ71j5BvG2LKESDEBEx4fJbNKwQegkhHqqL304mFobdF3hoHNhY2LDDkXPKMQFS6C6xEIdmDg=="],
 
     "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@ronin/cli": "0.2.39",
     "@ronin/compiler": "0.17.7",
-    "@ronin/syntax": "0.2.29"
+    "@ronin/syntax": "0.2.30"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
This change fixes a small problem with the sql function where if you placed any `--` comments inside template string it will fail the request because there is no way to determine the end of the comment. Instead we will strip any & all comments from raw SQL queries.

Originally, the change was landed in ronin-co/syntax#60.