### PR TITLE
Ensure correct model-specific queries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.2.39",
-        "@ronin/compiler": "0.17.11",
+        "@ronin/compiler": "0.17.12",
         "@ronin/syntax": "0.2.32",
       },
       "devDependencies": {
@@ -173,7 +173,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.2.39", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-r3yEBOCuVyTXOPouJKC/LWLByXE73TJo5bSFsYIDN04lKxBvCjrzGAfFJ8tMVdEeeBxz4slhoQkbWIxmysWuIQ=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.11", "", {}, "sha512-6lPjWe8tHShsrAhVR1KnEKBgCf2YjC0WHjMu7TSsg0DmveSmUcFJbv9hdie2ERjcQFnq31xRzRQUESsFIEYAow=="],
+    "@ronin/compiler": ["@ronin/compiler@0.17.12", "", {}, "sha512-bYTv/6i2d6wCxuL+ULxPkIkBrrPFJfLrtaLI/SYksJ+G+E1Q1a6GBJ4/MUTRoqZkYnB5wWHvbY40TUlh9vKlag=="],
 
     "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@ronin/cli": "0.2.39",
-    "@ronin/compiler": "0.17.11",
+    "@ronin/compiler": "0.17.12",
     "@ronin/syntax": "0.2.32"
   },
   "devDependencies": {


### PR DESCRIPTION
This change ensures that providing model-specific instructions for a query that affects all models (such as `get.all()`) works correctly, by ensuring that fields are selected as desired.

Originally, the change was landed in https://github.com/ronin-co/compiler/pull/156.