### PR TITLE
Allow for returning full queries from "before" hooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.2.40",
-        "@ronin/compiler": "0.17.14",
+        "@ronin/compiler": "0.17.15",
         "@ronin/syntax": "0.2.33",
       },
       "devDependencies": {
@@ -173,7 +173,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.2.40", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-UTs0bCjO7vTYpCp9o9QJQrcP7X9vFQxl8nBBdHI786rgJLDbpMo0tUF3bwEFrQMCLx6J+VwsIW/Umn4EcMBzyw=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.14", "", {}, "sha512-4MCsZ+rarnSG0px2y+QlAkXTtAvWm8D/GwDKvtXuJHBtlfxRyxpqgm6VVx1FnAn327047VQnJ1sg4rmxbiX/pA=="],
+    "@ronin/compiler": ["@ronin/compiler@0.17.15", "", {}, "sha512-c6+s4VXNKsmogWy+WZYXc91q7usQFx3EEE5ow8jW1lK9yKDBlHXPQxWbkVS+FxYFcNOqbbI08QDUVN7WuyaiLQ=="],
 
     "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.2.40",
-        "@ronin/compiler": "0.17.13",
+        "@ronin/compiler": "0.17.14",
         "@ronin/syntax": "0.2.33",
       },
       "devDependencies": {
@@ -173,7 +173,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.2.40", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-UTs0bCjO7vTYpCp9o9QJQrcP7X9vFQxl8nBBdHI786rgJLDbpMo0tUF3bwEFrQMCLx6J+VwsIW/Umn4EcMBzyw=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.13", "", {}, "sha512-mK5wOf2mNeqQmAy6D0lDQ9oip2dXfXJuI9ba4yjoVNb0zrS8OWPDrX98ATjfNE5sDpZbdmCwmRWgSSGXZBAMig=="],
+    "@ronin/compiler": ["@ronin/compiler@0.17.14", "", {}, "sha512-4MCsZ+rarnSG0px2y+QlAkXTtAvWm8D/GwDKvtXuJHBtlfxRyxpqgm6VVx1FnAn327047VQnJ1sg4rmxbiX/pA=="],
 
     "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@ronin/cli": "0.2.40",
-    "@ronin/compiler": "0.17.13",
+    "@ronin/compiler": "0.17.14",
     "@ronin/syntax": "0.2.33"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@ronin/cli": "0.2.40",
-    "@ronin/compiler": "0.17.14",
+    "@ronin/compiler": "0.17.15",
     "@ronin/syntax": "0.2.33"
   },
   "devDependencies": {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -6,11 +6,11 @@ import type {
   QueryResponse,
   RegularFormattedResult,
 } from '@/src/types/utils';
-import { WRITE_QUERY_TYPES } from '@/src/utils/constants';
 import { runQueriesWithHooks } from '@/src/utils/data-hooks';
 import { getResponseBody } from '@/src/utils/errors';
 import { formatDateFields } from '@/src/utils/helpers';
 import {
+  DML_WRITE_QUERY_TYPES,
   type Model,
   type Query,
   type RegularResult,
@@ -48,7 +48,7 @@ export const runQueries = async <T extends ResultRecord>(
     }));
   } else {
     hasWriteQuery = queries.some((query) =>
-      WRITE_QUERY_TYPES.includes(Object.keys(query)[0]),
+      (DML_WRITE_QUERY_TYPES as ReadonlyArray<string>).includes(Object.keys(query)[0]),
     );
 
     if (options.models) {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -10,7 +10,7 @@ import { runQueriesWithHooks } from '@/src/utils/data-hooks';
 import { getResponseBody } from '@/src/utils/errors';
 import { formatDateFields } from '@/src/utils/helpers';
 import {
-  DML_WRITE_QUERY_TYPES,
+  DML_QUERY_TYPES_WRITE,
   type Model,
   type Query,
   type RegularResult,
@@ -48,7 +48,7 @@ export const runQueries = async <T extends ResultRecord>(
     }));
   } else {
     hasWriteQuery = queries.some((query) =>
-      (DML_WRITE_QUERY_TYPES as ReadonlyArray<string>).includes(Object.keys(query)[0]),
+      (DML_QUERY_TYPES_WRITE as ReadonlyArray<string>).includes(Object.keys(query)[0]),
     );
 
     if (options.models) {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -6,6 +6,7 @@ import type {
   QueryResponse,
   RegularFormattedResult,
 } from '@/src/types/utils';
+import { WRITE_QUERY_TYPES } from '@/src/utils/constants';
 import { runQueriesWithHooks } from '@/src/utils/data-hooks';
 import { getResponseBody } from '@/src/utils/errors';
 import { formatDateFields } from '@/src/utils/helpers';
@@ -48,7 +49,7 @@ export const runQueries = async <T extends ResultRecord>(
     }));
   } else {
     hasWriteQuery = queries.some((query) =>
-      (DML_QUERY_TYPES_WRITE as ReadonlyArray<string>).includes(Object.keys(query)[0]),
+      WRITE_QUERY_TYPES.includes(Object.keys(query)[0]),
     );
 
     if (options.models) {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -11,7 +11,6 @@ import { runQueriesWithHooks } from '@/src/utils/data-hooks';
 import { getResponseBody } from '@/src/utils/errors';
 import { formatDateFields } from '@/src/utils/helpers';
 import {
-  DML_QUERY_TYPES_WRITE,
   type Model,
   type Query,
   type RegularResult,
@@ -49,7 +48,7 @@ export const runQueries = async <T extends ResultRecord>(
     }));
   } else {
     hasWriteQuery = queries.some((query) =>
-      WRITE_QUERY_TYPES.includes(Object.keys(query)[0]),
+      (WRITE_QUERY_TYPES as ReadonlyArray<string>).includes(Object.keys(query)[0]),
     );
 
     if (options.models) {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,4 @@
 import { DDL_QUERY_TYPES, DML_QUERY_TYPES_WRITE } from '@ronin/compiler';
 
 /** A list of all query types that update the database. */
-export const WRITE_QUERY_TYPES = [...DML_QUERY_TYPES_WRITE, DDL_QUERY_TYPES] as const;
+export const WRITE_QUERY_TYPES = [...DML_QUERY_TYPES_WRITE, ...DDL_QUERY_TYPES];

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,4 @@
 import { DDL_QUERY_TYPES, DML_QUERY_TYPES_WRITE } from '@ronin/compiler';
 
 /** A list of all query types that update the database. */
-export const WRITE_QUERY_TYPES = [...DML_QUERY_TYPES_WRITE, DDL_QUERY_TYPES];
+export const WRITE_QUERY_TYPES = [...DML_QUERY_TYPES_WRITE, DDL_QUERY_TYPES] as const;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,4 @@
+import { DDL_QUERY_TYPES, DML_QUERY_TYPES_WRITE } from '@ronin/compiler';
+
+/** A list of all query types that update the database. */
+export const WRITE_QUERY_TYPES = [...DML_QUERY_TYPES_WRITE, DDL_QUERY_TYPES];

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,0 @@
-/** A list of all query types that update the database. */
-export const WRITE_QUERY_TYPES = ['add', 'set', 'remove', 'create', 'alter', 'drop'];

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -7,7 +7,8 @@ import type {
 import { toDashCase } from '@/src/utils/helpers';
 import {
   type CombinedInstructions,
-  DML_WRITE_QUERY_TYPES,
+  DML_QUERY_TYPES_WRITE,
+  QUERY_TYPES,
   type Query,
   type QuerySchemaType,
   type QueryType,
@@ -272,14 +273,7 @@ const invokeHooks = async (
   const parentHook = asyncContext.getStore();
   const shouldSkip =
     hooksForSchema &&
-    (hooksForSchema.get ||
-      hooksForSchema.count ||
-      hooksForSchema.add ||
-      hooksForSchema.set ||
-      hooksForSchema.remove ||
-      hooksForSchema.create ||
-      hooksForSchema.alter ||
-      hooksForSchema.drop) &&
+    QUERY_TYPES.some((type) => type in hooksForSchema) &&
     parentHook &&
     querySchema !== parentHook.querySchema
       ? false
@@ -480,7 +474,7 @@ export const runQueriesWithHooks = async <T extends ResultRecord>(
     const queryType = Object.keys(query.definition)[0] as QueryType;
 
     // "after" hooks should only fire for writes — not reads.
-    if (!(DML_WRITE_QUERY_TYPES as ReadonlyArray<string>).includes(queryType)) continue;
+    if (!(DML_QUERY_TYPES_WRITE as ReadonlyArray<string>).includes(queryType)) continue;
 
     const diffMatch = queryList.find((item) => item.diffForIndex === index);
 

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -315,11 +315,11 @@ const invokeHooks = async (
     // If the hook returned a query, we want to replace the original query with
     // the one returned by the hook.
     if (hookType === 'before') {
-      const result = hookResult as Query | CombinedInstructions;
+      const result = hookResult as null | Query | CombinedInstructions;
       let newQuery: Query = query.definition;
 
       // If a full query was returned by the "before" hook, use the query as-is.
-      if (QUERY_TYPES.some((type) => type in result)) {
+      if (result && QUERY_TYPES.some((type) => type in result)) {
         newQuery = result as Query;
       }
       // In the majority of cases, however, only the query instructions are returned, in

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -8,7 +8,6 @@ import { WRITE_QUERY_TYPES } from '@/src/utils/constants';
 import { toDashCase } from '@/src/utils/helpers';
 import {
   type CombinedInstructions,
-  DML_QUERY_TYPES_WRITE,
   QUERY_TYPES,
   type Query,
   type QuerySchemaType,
@@ -475,7 +474,7 @@ export const runQueriesWithHooks = async <T extends ResultRecord>(
     const queryType = Object.keys(query.definition)[0] as QueryType;
 
     // "after" hooks should only fire for writes — not reads.
-    if (!WRITE_QUERY_TYPES.includes(queryType)) continue;
+    if (!(WRITE_QUERY_TYPES as ReadonlyArray<string>).includes(queryType)) continue;
 
     const diffMatch = queryList.find((item) => item.diffForIndex === index);
 

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -4,6 +4,7 @@ import type {
   QueryHandlerOptions,
   RecursivePartial,
 } from '@/src/types/utils';
+import { WRITE_QUERY_TYPES } from '@/src/utils/constants';
 import { toDashCase } from '@/src/utils/helpers';
 import {
   type CombinedInstructions,
@@ -474,7 +475,7 @@ export const runQueriesWithHooks = async <T extends ResultRecord>(
     const queryType = Object.keys(query.definition)[0] as QueryType;
 
     // "after" hooks should only fire for writes — not reads.
-    if (!(DML_QUERY_TYPES_WRITE as ReadonlyArray<string>).includes(queryType)) continue;
+    if (!WRITE_QUERY_TYPES.includes(queryType)) continue;
 
     const diffMatch = queryList.find((item) => item.diffForIndex === index);
 

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -4,14 +4,14 @@ import type {
   QueryHandlerOptions,
   RecursivePartial,
 } from '@/src/types/utils';
-import { WRITE_QUERY_TYPES } from '@/src/utils/constants';
 import { toDashCase } from '@/src/utils/helpers';
-import type {
-  CombinedInstructions,
-  Query,
-  QuerySchemaType,
-  QueryType,
-  ResultRecord,
+import {
+  type CombinedInstructions,
+  DML_WRITE_QUERY_TYPES,
+  type Query,
+  type QuerySchemaType,
+  type QueryType,
+  type ResultRecord,
 } from '@ronin/compiler';
 
 const EMPTY = Symbol('empty');
@@ -480,7 +480,7 @@ export const runQueriesWithHooks = async <T extends ResultRecord>(
     const queryType = Object.keys(query.definition)[0] as QueryType;
 
     // "after" hooks should only fire for writes — not reads.
-    if (!WRITE_QUERY_TYPES.includes(queryType)) continue;
+    if (!(DML_WRITE_QUERY_TYPES as ReadonlyArray<string>).includes(queryType)) continue;
 
     const diffMatch = queryList.find((item) => item.diffForIndex === index);
 

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -97,6 +97,30 @@ describe('hooks', () => {
     );
   });
 
+  test('return full query from `before` data hook', async () => {
+    const { get } = createSyntaxFactory({
+      hooks: {
+        account: {
+          beforeGet(query) {
+            return {
+              get: {
+                team: query,
+              },
+            };
+          },
+        },
+      },
+      asyncContext: new AsyncLocalStorage(),
+    });
+
+    // @ts-expect-error `handle` is undefined due not not having the schema types.
+    await get.account.with.handle('juri');
+
+    expect(mockResolvedRequestText).toEqual(
+      JSON.stringify({ queries: [{ get: { team: { with: { handle: 'leo' } } } }] }),
+    );
+  });
+
   test('run `get` query through factory with dynamically generated config', async () => {
     const { get } = createSyntaxFactory(() => ({
       hooks: {

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -114,10 +114,10 @@ describe('hooks', () => {
     });
 
     // @ts-expect-error `handle` is undefined due not not having the schema types.
-    await get.account.with.handle('juri');
+    await get.account.with.handle('elaine');
 
     expect(mockResolvedRequestText).toEqual(
-      JSON.stringify({ queries: [{ get: { team: { with: { handle: 'leo' } } } }] }),
+      JSON.stringify({ queries: [{ get: { team: { with: { handle: 'elaine' } } } }] }),
     );
   });
 


### PR DESCRIPTION
This change makes it possible to return complete queries from "before" hooks instead of requiring only the instructions of the query to be returned.

In the majority of cases, people will only need to return the instructions, but in the case that a full query targeting a different model must be returned, that's now possible as well.