### PR TITLE
Pass default options to data hooks

### DIFF
--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -22,7 +22,10 @@ import {
 const EMPTY = Symbol('empty');
 
 interface DataHookOptions {
+  /** The model for which the query is being executed. */
   model?: string;
+  /** The database for which the query is being executed. */
+  database?: string;
 }
 
 export type FilteredHookQuery<
@@ -310,7 +313,8 @@ const invokeHooks = async (
 
   if (hooksForModel && hookName in hooksForModel && !shouldSkip) {
     const hook = hooksForModel[hookName as keyof typeof hooksForModel];
-    const hookOptions = hookFile === 'sink' ? { model: queryModel } : {};
+    const hookOptions =
+      hookFile === 'sink' ? { model: queryModel, database: options.database } : {};
 
     const hookResult = await asyncContext.run(
       {

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -469,24 +469,24 @@ export const runQueriesWithHooks = async <T extends ResultRecord>(
       // For diff queries, we don't want to run "before" hooks.
       if (typeof diffForIndex !== 'undefined') return;
 
-      const modifiedQuery = await invokeHooks(
+      const hookResults = await invokeHooks(
         'before',
         { query },
         { ...hookCallerOptions, database },
       );
-      queryList[index].query = modifiedQuery.query;
+      queryList[index].query = hookResults.query;
     }),
   );
 
   // Invoke `get`, `set`, `add`, `remove`, and `count`.
   await Promise.all(
     queryList.map(async ({ query, database }, index) => {
-      const modifiedQuery = await invokeHooks(
+      const hookResults = await invokeHooks(
         'during',
         { query },
         { ...hookCallerOptions, database },
       );
-      queryList[index].result = modifiedQuery.result as FormattedResults<T>[number];
+      queryList[index].result = hookResults.result as FormattedResults<T>[number];
     }),
   );
 

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -695,7 +695,7 @@ describe('hooks', () => {
       },
     );
 
-    const expectedOptions = { model: 'product' };
+    const expectedOptions = { model: 'product', database: 'secondary' };
 
     expect(beforeAddOptions).toMatchObject(expectedOptions);
     expect(duringAddOptions).toMatchObject(expectedOptions);

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -3,8 +3,15 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
 import { createSyntaxFactory } from '@/src/index';
-import { type FilteredHookQuery, runQueriesWithHooks } from '@/src/utils/data-hooks';
-import type { CombinedInstructions, QueryType } from '@ronin/compiler';
+import { runQueriesWithStorageAndHooks } from '@/src/queries';
+import {
+  type AddHook,
+  type AfterAddHook,
+  type BeforeAddHook,
+  type FilteredHookQuery,
+  runQueriesWithHooks,
+} from '@/src/utils/data-hooks';
+import type { CombinedInstructions, Query, QueryType } from '@ronin/compiler';
 
 let mockResolvedRequestText: any;
 
@@ -613,5 +620,98 @@ describe('hooks', () => {
     expect(error?.message).toMatch(
       `In the case that the "ronin" package receives a value for its \`hooks\` option, it must also receive a value for its \`asyncContext\` option.`,
     );
+  });
+
+  test('receive options for sink hook', async () => {
+    const mockFetchNew = mock(() => {
+      return Response.json({
+        default: {
+          results: [
+            {
+              record: {
+                handle: 'elaine',
+              },
+              modelFields: {
+                name: 'string',
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    const defaultQueries: Array<Query> = [
+      {
+        add: {
+          account: {
+            with: {
+              handle: 'elaine',
+            },
+          },
+        },
+      },
+    ];
+
+    const secondaryQueries: Array<Query> = [
+      {
+        add: {
+          product: {
+            with: {
+              name: 'MacBook Pro',
+            },
+          },
+        },
+      },
+    ];
+
+    let beforeAddOptions: Parameters<BeforeAddHook>[2] | undefined;
+    let duringAddOptions: Parameters<AddHook>[2] | undefined;
+    let afterAddOptions: Parameters<AfterAddHook>[4] | undefined;
+
+    const results = await runQueriesWithStorageAndHooks(
+      {
+        default: defaultQueries,
+        secondary: secondaryQueries,
+      },
+      {
+        fetch: async () => mockFetchNew(),
+        token: 'takashitoken',
+        hooks: {
+          sink: {
+            beforeAdd: (query, _multiple, options) => {
+              beforeAddOptions = options;
+              return query;
+            },
+            add: (query, _multiple, options) => {
+              duringAddOptions = options;
+              return query.with;
+            },
+            afterAdd: (_query, _multiple, _beforeResult, _afterResult, options) => {
+              afterAddOptions = options;
+            },
+          },
+        },
+        asyncContext: new AsyncLocalStorage(),
+      },
+    );
+
+    const expectedOptions = { model: 'product' };
+
+    expect(beforeAddOptions).toMatchObject(expectedOptions);
+    expect(duringAddOptions).toMatchObject(expectedOptions);
+    expect(afterAddOptions).toMatchObject(expectedOptions);
+
+    expect(results).toMatchObject({
+      default: [
+        {
+          handle: 'elaine',
+        },
+      ],
+      secondary: [
+        {
+          name: 'MacBook Pro',
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
This change ensures that the recently introduced "sink" data hook¹ receives an option that identifies the model and the database for which the query is being run.

---

¹ The data hook that captures all queries that are not targeting the "default" database.