### PR TITLE
Adjust types for returning full queries from "before" hooks

### DIFF
--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -54,7 +54,7 @@ export type BeforeHookHandler<
   query: TQuery,
   multipleRecords: boolean,
   options: DataHookOptions,
-) => TQuery | Promise<TQuery>;
+) => TQuery | Promise<TQuery> | Query;
 
 export type DuringHookHandler<TType extends QueryType, TSchema = unknown> = (
   query: FilteredHookQuery<TType>,

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -95,7 +95,7 @@ type Hook<
       : never;
 
 type HookList<TSchema = unknown> = {
-  [K in HookKeys]?: K extends 'before'
+  [K in HookKeys]?: K extends 'before' | `before${string}`
     ? BeforeHookHandler<QueryType>
     : K extends 'after' | `after${string}`
       ? AfterHookHandler<QueryType, TSchema>

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -29,8 +29,8 @@ interface DataHookOptions {
 }
 
 export type FilteredHookQuery<
-  TQuery extends CombinedInstructions,
   TType extends QueryType,
+  TQuery extends CombinedInstructions = CombinedInstructions,
 > = RecursivePartial<TQuery> &
   Pick<
     TQuery,
@@ -49,10 +49,7 @@ export type FilteredHookQuery<
 
 export type BeforeHookHandler<
   TType extends QueryType,
-  TQuery extends FilteredHookQuery<CombinedInstructions, TType> = FilteredHookQuery<
-    CombinedInstructions,
-    TType
-  >,
+  TQuery extends FilteredHookQuery<TType> = FilteredHookQuery<TType>,
 > = (
   query: TQuery,
   multipleRecords: boolean,
@@ -60,13 +57,13 @@ export type BeforeHookHandler<
 ) => TQuery | Promise<TQuery>;
 
 export type DuringHookHandler<TType extends QueryType, TSchema = unknown> = (
-  query: FilteredHookQuery<CombinedInstructions, TType>,
+  query: FilteredHookQuery<TType>,
   multipleRecords: boolean,
   options: DataHookOptions,
 ) => TSchema | Promise<TSchema>;
 
 export type AfterHookHandler<TType extends QueryType, TSchema = unknown> = (
-  query: FilteredHookQuery<CombinedInstructions, TType>,
+  query: FilteredHookQuery<TType>,
   multipleRecords: boolean,
   beforeResult: TSchema,
   afterResult: TSchema,

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -204,7 +204,7 @@ describe('hooks', () => {
   });
 
   test('run `create` query through factory containing `after` data hook', async () => {
-    let finalQuery: FilteredHookQuery<CombinedInstructions, QueryType> | undefined;
+    let finalQuery: FilteredHookQuery<QueryType> | undefined;
     let finalMultiple: boolean | undefined;
     let finalBeforeResult: unknown;
     let finalAfterResult: unknown;
@@ -261,7 +261,7 @@ describe('hooks', () => {
   });
 
   test('run `alter` query through factory containing `after` data hook', async () => {
-    let finalQuery: FilteredHookQuery<CombinedInstructions, QueryType> | undefined;
+    let finalQuery: FilteredHookQuery<QueryType> | undefined;
     let finalMultiple: boolean | undefined;
     let finalBeforeResult: unknown;
     let finalAfterResult: unknown;
@@ -410,7 +410,7 @@ describe('hooks', () => {
   });
 
   test('run `set` query affecting multiple accounts through factory containing `after` data hook', async () => {
-    let finalQuery: FilteredHookQuery<CombinedInstructions, QueryType> | undefined;
+    let finalQuery: FilteredHookQuery<QueryType> | undefined;
     let finalMultiple: boolean | undefined;
     let finalBeforeResult: unknown;
     let finalAfterResult: unknown;
@@ -492,7 +492,7 @@ describe('hooks', () => {
   });
 
   test('run normal queries alongside queries that are handled by `during` hook', async () => {
-    let finalQuery: FilteredHookQuery<CombinedInstructions, QueryType> | undefined;
+    let finalQuery: FilteredHookQuery<QueryType> | undefined;
     let finalMultiple: boolean | undefined;
     let mockResolvedRequestText: string | undefined;
 

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -108,11 +108,13 @@ describe('hooks', () => {
       hooks: {
         account: {
           beforeGet(query) {
-            return {
+            const fullQuery: Query = {
               get: {
                 team: query,
               },
             };
+
+            return fullQuery;
           },
         },
       },


### PR DESCRIPTION
In https://github.com/ronin-co/client/pull/83, we made it possible to return full queries (instead of just query instructions) from "before" data hooks.

The current change ensures that the types reflect this accordingly, which previously wasn't the case.

It also ensures that the types for `before*` hooks are applied correctly, which previously also wasn't the case.