### PR TITLE
Run "before" hooks for diff queries

### DIFF
--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -466,10 +466,7 @@ export const runQueriesWithHooks = async <T extends ResultRecord>(
 
   // Invoke `beforeAdd`, `beforeGet`, `beforeSet`, `beforeRemove`, and `beforeCount`.
   await Promise.all(
-    queryList.map(async ({ query, diffForIndex, database }, index) => {
-      // For diff queries, we don't want to run "before" hooks.
-      if (typeof diffForIndex !== 'undefined') return;
-
+    queryList.map(async ({ query, database }, index) => {
       const hookResults = await invokeHooks(
         'before',
         { query },


### PR DESCRIPTION
This change ensures that "before" hooks are run for automatically generated diff queries too.

We generate diff queries in order to provide data hooks with "before" and "after" results of mutations.