### PR TITLE
Add `ronin types` command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "ronin",
       "dependencies": {
-        "@ronin/cli": "0.2.44",
+        "@ronin/cli": "0.3.0",
         "@ronin/compiler": "0.17.17",
         "@ronin/syntax": "0.2.36",
       },
@@ -173,7 +173,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.37.0", "", { "os": "win32", "cpu": "x64" }, "sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA=="],
 
-    "@ronin/cli": ["@ronin/cli@0.2.44", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-Ga+K+XS1YkBbsbkZ7lNshanqkz4TdfNcWXZIOaxbsG35hNts35wn0mv3CkGkQSDJCISapPeU6ZEbIVSwvZn25A=="],
+    "@ronin/cli": ["@ronin/cli@0.3.0", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-LfxwS5C0U/VdrAREEuq0VMoVgRIqVZdcjYkSX/abfU6xi+op7u5V4kfTaR9Ip4tgZFRHfFNR0CWQ+UhR8jfgxw=="],
 
     "@ronin/compiler": ["@ronin/compiler@0.17.17", "", {}, "sha512-uq17FQzCl6HeHoSsSkoXU2Enl8WfQd6uCC6sSGFRR171VbV6HHinW322KdlF1hN0khbYBoLoC/SNwXpfx7J/VQ=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "node": ">=18.17.0"
   },
   "dependencies": {
-    "@ronin/cli": "0.2.44",
+    "@ronin/cli": "0.3.0",
     "@ronin/compiler": "0.17.17",
     "@ronin/syntax": "0.2.36"
   },


### PR DESCRIPTION
This change adds a new `ronin types` sub command which handles generating the TypeScript types used for a space.

Along with some additional minor tweaks & fixes, such as upgrading the `ronin` dev dependency to the latest version.

This was landed in ronin-co/cli#69.