### PR TITLE
Correctly store model entity slug

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.3.0",
-        "@ronin/compiler": "0.17.17",
+        "@ronin/compiler": "0.17.20",
         "@ronin/syntax": "0.2.37",
       },
       "devDependencies": {
@@ -175,7 +175,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.3.0", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-LfxwS5C0U/VdrAREEuq0VMoVgRIqVZdcjYkSX/abfU6xi+op7u5V4kfTaR9Ip4tgZFRHfFNR0CWQ+UhR8jfgxw=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.17", "", {}, "sha512-uq17FQzCl6HeHoSsSkoXU2Enl8WfQd6uCC6sSGFRR171VbV6HHinW322KdlF1hN0khbYBoLoC/SNwXpfx7J/VQ=="],
+    "@ronin/compiler": ["@ronin/compiler@0.17.20", "", {}, "sha512-jIj6Agt6WCaUGCGaxkJBIAGplBlkLDONVYiKsgGJbDq1dPLQanp1gzbZJVh+Rm6c+8GYSZfQw2JDm3dk/CyPyg=="],
 
     "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@ronin/cli": "0.3.0",
-    "@ronin/compiler": "0.17.17",
+    "@ronin/compiler": "0.17.20",
     "@ronin/syntax": "0.2.37"
   },
   "devDependencies": {


### PR DESCRIPTION
This change ensures that the `slug` attribute of model entities (fields, indexes, etc.) is never stored as part of the attributes of the model entity within the model.

In other words, it prevents a scenario like this one from occurring:

```
fields: {
  test: { slug: test, ... }
}
```

Originally, the change was applied in https://github.com/ronin-co/compiler/pull/165.