### PR TITLE
Ensure correct pagination when selecting fields

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.3.0",
-        "@ronin/compiler": "0.17.21",
+        "@ronin/compiler": "0.17.22",
         "@ronin/syntax": "0.2.37",
       },
       "devDependencies": {
@@ -175,7 +175,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.3.0", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-LfxwS5C0U/VdrAREEuq0VMoVgRIqVZdcjYkSX/abfU6xi+op7u5V4kfTaR9Ip4tgZFRHfFNR0CWQ+UhR8jfgxw=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.21", "", {}, "sha512-Vvv0y7kMqrAwn4JJU/QJPhLVjwHW+CKDY3PwbGKe1ldIGBvWkBdvwx3YVvdWGhskvQ+g1s0pFDf304SRYqXtSQ=="],
+    "@ronin/compiler": ["@ronin/compiler@0.17.22", "", {}, "sha512-w8Q2NUKzhbwKpiM1LXJWOM5iBtvfRsf1wNcWo+gYRrhLx1x5TBgL0Or2Py/+C4+2fkgh+iR5VcoAAO4XCWo7Aw=="],
 
     "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@ronin/cli": "0.3.0",
-    "@ronin/compiler": "0.17.21",
+    "@ronin/compiler": "0.17.22",
     "@ronin/syntax": "0.2.37"
   },
   "devDependencies": {


### PR DESCRIPTION
This change improves the changes landed in https://github.com/ronin-co/compiler/pull/164 further, by ensuring that all fields used for ordering are automatically selected in the generated SQL statement, such that their values can be used to compose the pagination cursor during record formatting.

Originally, the changes were landed in https://github.com/ronin-co/compiler/pull/164 and https://github.com/ronin-co/compiler/pull/167.