### PR TITLE
Expose camel-case model slug to hooks

### DIFF
--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -275,15 +275,19 @@ const invokeHooks = async (
 
   const queryType = Object.keys(query)[0] as QueryType;
   const queryInstructions = query[queryType] as QuerySchemaType;
-  const { key, model: queryModel, multipleRecords } = getModel(queryInstructions);
-  const oldInstruction = queryInstructions[key];
+  const {
+    key: queryModel,
+    model: queryModelDashed,
+    multipleRecords,
+  } = getModel(queryInstructions);
+  const oldInstruction = queryInstructions[queryModel];
 
   // If the hooks are being executed for a custom database, all hooks must be located
   // inside a file named `sink.ts`, which catches the queries for all other databases.
   //
   // If the hooks are *not* being executed for a custom database, the hook file name
   // matches the model that is being addressed by the query.
-  const hookFile = options.database ? 'sink' : queryModel;
+  const hookFile = options.database ? 'sink' : queryModelDashed;
   const hooksForModel = hooks[hookFile];
   const hookName = getMethodName(hookType, queryType);
 
@@ -384,7 +388,7 @@ const invokeHooks = async (
       else {
         newQuery = {
           [queryType]: {
-            [key]: result as CombinedInstructions,
+            [queryModel]: result as CombinedInstructions,
           },
         };
       }

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -657,7 +657,9 @@ describe('hooks', () => {
     const secondaryQueries: Array<Query> = [
       {
         add: {
-          product: {
+          // We are purposefully using camel-case here in order to ensure that the final
+          // data hook options are formatted correctly.
+          someProduct: {
             with: {
               name: 'MacBook Pro',
             },
@@ -697,7 +699,7 @@ describe('hooks', () => {
       },
     );
 
-    const expectedOptions = { model: 'product', database: 'secondary' };
+    const expectedOptions = { model: 'someProduct', database: 'secondary' };
 
     expect(beforeAddOptions).toMatchObject(expectedOptions);
     expect(duringAddOptions).toMatchObject(expectedOptions);


### PR DESCRIPTION
This change ensures that the model slugs exposed to data hooks is camel-case, not dash-case.