### PR TITLE
Expose database selection option for queries

### DIFF
--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -37,6 +37,12 @@ export interface QueryHandlerOptions {
    * option is required.
    */
   asyncContext?: AsyncLocalStorage<any>;
+
+  /**
+   * If the query should be run for a specific database within your space, you may
+   * provide the desired database name here.
+   */
+  database?: string;
 }
 
 /**

--- a/src/utils/handlers.ts
+++ b/src/utils/handlers.ts
@@ -62,6 +62,13 @@ export const queriesHandler = async (
     return results.map(({ result }) => result);
   }
 
+  if (options.database) {
+    const queryList = { [options.database]: queries };
+    const result = await runQueriesWithStorageAndHooks(queryList, options);
+
+    return result[options.database];
+  }
+
   return runQueriesWithStorageAndHooks(queries, options);
 };
 

--- a/tests/integration/factory.test.ts
+++ b/tests/integration/factory.test.ts
@@ -79,6 +79,49 @@ describe('factory', () => {
     );
   });
 
+  test('can use the custom database', async () => {
+    const mockFetchNew = mock((request) => {
+      mockRequestResolvedValue = request;
+
+      return Response.json({
+        databaseName: {
+          results: [
+            {
+              record: {
+                name: 'Tim',
+                createdAt: '2024-04-16T15:02:12.710Z',
+                ronin: {
+                  updatedAt: '2024-05-16T15:02:12.710Z',
+                },
+              },
+              modelFields: {
+                name: 'string',
+                createdAt: 'date',
+                'ronin.updatedAt': 'date',
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    const factory = createSyntaxFactory({
+      fetch: async (request) => mockFetchNew(request),
+      database: 'databaseName',
+      token: 'takashitoken',
+    });
+
+    const record = await factory.get.account();
+
+    expect(record).toMatchObject({
+      name: 'Tim',
+      createdAt: new Date('2024-04-16T15:02:12.710Z'),
+      ronin: {
+        updatedAt: new Date('2024-05-16T15:02:12.710Z'),
+      },
+    });
+  });
+
   test('send correct `queries` for single `get` request', async () => {
     await get.accounts();
 

--- a/tests/integration/factory.test.ts
+++ b/tests/integration/factory.test.ts
@@ -79,7 +79,7 @@ describe('factory', () => {
     );
   });
 
-  test('can use the custom database', async () => {
+  test('can use custom database', async () => {
     const mockFetchNew = mock((request) => {
       mockRequestResolvedValue = request;
 
@@ -107,11 +107,15 @@ describe('factory', () => {
 
     const factory = createSyntaxFactory({
       fetch: async (request) => mockFetchNew(request),
-      database: 'databaseName',
       token: 'takashitoken',
     });
 
-    const record = await factory.get.account();
+    const record = await factory.get.account(
+      {},
+      {
+        database: 'databaseName',
+      },
+    );
 
     expect(record).toMatchObject({
       name: 'Tim',
@@ -120,6 +124,81 @@ describe('factory', () => {
         updatedAt: new Date('2024-05-16T15:02:12.710Z'),
       },
     });
+  });
+
+  test('can use custom database in batch', async () => {
+    const mockFetchNew = mock((request) => {
+      mockRequestResolvedValue = request;
+
+      return Response.json({
+        databaseName: {
+          results: [
+            {
+              record: {
+                name: 'Tim',
+                handle: 'tim',
+                createdAt: '2024-04-16T15:02:12.710Z',
+                ronin: {
+                  updatedAt: '2024-05-16T15:02:12.710Z',
+                },
+              },
+              modelFields: {
+                name: 'string',
+                createdAt: 'date',
+                'ronin.updatedAt': 'date',
+              },
+            },
+            {
+              record: {
+                name: 'David',
+                handle: 'david',
+                createdAt: '2024-04-16T15:02:12.710Z',
+                ronin: {
+                  updatedAt: '2024-05-16T15:02:12.710Z',
+                },
+              },
+              modelFields: {
+                name: 'string',
+                createdAt: 'date',
+                'ronin.updatedAt': 'date',
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    const factory = createSyntaxFactory({
+      fetch: async (request) => mockFetchNew(request),
+      token: 'takashitoken',
+    });
+
+    const records = await factory.batch(
+      () => [
+        factory.get.account.with.handle('tim'),
+        factory.get.account.with.handle('david'),
+      ],
+      { database: 'databaseName' },
+    );
+
+    expect(records).toMatchObject([
+      {
+        name: 'Tim',
+        handle: 'tim',
+        createdAt: new Date('2024-04-16T15:02:12.710Z'),
+        ronin: {
+          updatedAt: new Date('2024-05-16T15:02:12.710Z'),
+        },
+      },
+      {
+        name: 'David',
+        handle: 'david',
+        createdAt: new Date('2024-04-16T15:02:12.710Z'),
+        ronin: {
+          updatedAt: new Date('2024-05-16T15:02:12.710Z'),
+        },
+      },
+    ]);
   });
 
   test('send correct `queries` for single `get` request', async () => {


### PR DESCRIPTION
In https://github.com/ronin-co/client/pull/84, we made it possible to access specific databases through the exported `runQueries` method.

The current change exposes that same logic through a new `database` option available for individual queries and batches.