### PR TITLE
Expose previous model to data hooks

### DIFF
--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -312,7 +312,7 @@ describe('hooks', () => {
       asyncContext: new AsyncLocalStorage(),
     });
 
-    const model = await (alter as unknown as (details: object) => unknown)({
+    await (alter as unknown as (details: object) => unknown)({
       model: 'account',
       to: {
         slug: 'user',

--- a/tests/integration/hooks.test.ts
+++ b/tests/integration/hooks.test.ts
@@ -270,18 +270,31 @@ describe('hooks', () => {
     let finalBeforeResult: unknown;
     let finalAfterResult: unknown;
 
+    const previousModel = {
+      id: '1',
+      slug: 'account',
+      pluralSlug: 'accounts',
+      name: 'Account',
+      pluralName: 'Accounts',
+    };
+
+    const nextModel = {
+      id: '1',
+      slug: 'user',
+      pluralSlug: 'users',
+      name: 'User',
+      pluralName: 'Users',
+    };
+
     const { alter } = createSyntaxFactory({
       fetch: async () => {
         return Response.json({
           results: [
             {
-              record: {
-                id: '1',
-                slug: 'account',
-                pluralSlug: 'accounts',
-                name: 'Account',
-                pluralName: 'Accounts',
-              },
+              record: previousModel,
+            },
+            {
+              record: nextModel,
             },
           ],
         });
@@ -319,10 +332,10 @@ describe('hooks', () => {
     //
     // We must use `toMatchObject` here, to ensure that the array is really
     // empty and doesn't contain any `undefined` items.
-    expect(finalBeforeResult).toMatchObject([]);
+    expect(finalBeforeResult).toMatchObject([previousModel]);
 
     // Make sure `finalAfterResult` matches the resolved account.
-    expect(finalAfterResult).toEqual([model]);
+    expect(finalAfterResult).toEqual([nextModel]);
 
     expect(finalMultiple).toBe(false);
   });


### PR DESCRIPTION
If data hooks are provided to the client, they currently already receive the previous version of a record in the `afterSet` data hook, in order to allow for comparing records before and after their modification.

The current change ensures that the same happens when models are altered, meaning in the `afterAlter` data hook.