### PR TITLE
Free up "model" slug for models

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.3.2",
-        "@ronin/compiler": "0.17.22",
+        "@ronin/compiler": "0.18.0",
         "@ronin/syntax": "0.2.37",
       },
       "devDependencies": {
@@ -175,7 +175,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.3.2", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.16", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-CBSDhRtd7BkRd4JO5s4b/AUXkw75nnUiV8LSKwNQxcYZFlcEWbr5xWfnxF1zP3Iv1uGpZTvzCI6naeAePSGmZA=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.22", "", {}, "sha512-w8Q2NUKzhbwKpiM1LXJWOM5iBtvfRsf1wNcWo+gYRrhLx1x5TBgL0Or2Py/+C4+2fkgh+iR5VcoAAO4XCWo7Aw=="],
+    "@ronin/compiler": ["@ronin/compiler@0.18.0", "", {}, "sha512-r6s90ylJWwpTJdJ+GOwku2DOaelgKJTn90RGSr5fMfLwayihK3RdRGYrMciBLgLX0Z7g6elqa0CIf5CjVr/Gxw=="],
 
     "@ronin/engine": ["@ronin/engine@0.1.16", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-u1+MNPhj5XtLLCXcDNq6dlcYyb0B/VHndyZOJzFWPEXIIWj5ULdAHJ04VT/Gvmjxb3UlBN0EZIgA1ycNL8H5+w=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@ronin/cli": "0.3.2",
-    "@ronin/compiler": "0.17.22",
+    "@ronin/compiler": "0.18.0",
     "@ronin/syntax": "0.2.37"
   },
   "devDependencies": {


### PR DESCRIPTION
This change makes it possible to use the slug "model" when defining models. For example, a modeling agency might want to do that in order to define the list of people they work with.

As a result, the `get.models()` query was changed to `list.models()`, in order to complete the separation of DDL (Data Definition Language) queries from DML (Data Manipulation Language) queries.

Additionally, a new `list.model('...')` query was added for retrieving a model with a specific slug. This is necessary in order for us to be able to diff two models using queries (before & after). The `list` query type will likely evolve further in the future, just like `create`, `alter`, and `drop` (of course "listing" a single model is not entirely logical).

Originally, the change was landed in https://github.com/ronin-co/compiler/pull/168.