### PR TITLE
Expose `list` query type

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.3.3",
-        "@ronin/compiler": "0.18.0",
+        "@ronin/compiler": "0.18.1",
         "@ronin/syntax": "0.2.37",
       },
       "devDependencies": {
@@ -175,7 +175,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.3.3", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-rbwi+qboAjOeWguARWzlgtclS0TACQtGxqJhJpSeE/1ickzxsQCrfxXpaFPa1Pfq6u3upiVz5xaT0d5VnC3eZg=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.18.0", "", {}, "sha512-r6s90ylJWwpTJdJ+GOwku2DOaelgKJTn90RGSr5fMfLwayihK3RdRGYrMciBLgLX0Z7g6elqa0CIf5CjVr/Gxw=="],
+    "@ronin/compiler": ["@ronin/compiler@0.18.1", "", {}, "sha512-hCxs8prvHx98nP4Z3VZT0D6IPKL6adakruq2k3BjxNRYtS/r2EfRhrbEI/V3+L7WbYGH2A9FO0brr3/HUgj7wQ=="],
 
     "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@ronin/cli": "0.3.3",
-    "@ronin/compiler": "0.18.0",
+    "@ronin/compiler": "0.18.1",
     "@ronin/syntax": "0.2.37"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   type CreateQuery,
   type DropQuery,
   type GetQuery,
+  type ListQuery,
   type ModelField,
   type ModelIndex,
   type ModelPreset,
@@ -80,6 +81,7 @@ export const createSyntaxFactory = (
   remove: DeepCallable<RemoveQuery>;
   count: DeepCallable<CountQuery, number>;
 
+  list: DeepCallable<ListQuery>;
   create: DeepCallable<CreateQuery, Model>;
   alter: DeepCallable<
     AlterQuery,
@@ -135,6 +137,11 @@ export const createSyntaxFactory = (
     }),
 
     // Query types for interacting with the database schema.
+    list: getSyntaxProxy<ListQuery>({
+      root: `${QUERY_SYMBOLS.QUERY}.list`,
+      callback,
+      replacer,
+    }),
     create: getSyntaxProxy<CreateQuery, Model>({
       root: `${QUERY_SYMBOLS.QUERY}.create`,
       callback,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,7 @@
 import { DDL_QUERY_TYPES, DML_QUERY_TYPES_WRITE } from '@ronin/compiler';
 
 /** A list of all query types that update the database. */
-export const WRITE_QUERY_TYPES = [...DML_QUERY_TYPES_WRITE, ...DDL_QUERY_TYPES];
+export const WRITE_QUERY_TYPES = [
+  ...DML_QUERY_TYPES_WRITE,
+  ...DDL_QUERY_TYPES.filter((item) => item !== 'list'),
+];


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/client/pull/109 and ensures that the TypeScript types for the `list` query type are being exported.