### PR TITLE
Don't duplicate fields from `selecting` and `using`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.3.5",
-        "@ronin/compiler": "0.18.1",
+        "@ronin/compiler": "0.18.2",
         "@ronin/syntax": "0.2.37",
       },
       "devDependencies": {
@@ -175,7 +175,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.3.5", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-mrHRpEfUSnTaifvdGJClCo2Nf6OwxwOcJ/ZABx65YHeihkuE6sUNBy7zaCWCea4jZkFvQW/vlcOUrDtzBxz2xg=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.18.1", "", {}, "sha512-hCxs8prvHx98nP4Z3VZT0D6IPKL6adakruq2k3BjxNRYtS/r2EfRhrbEI/V3+L7WbYGH2A9FO0brr3/HUgj7wQ=="],
+    "@ronin/compiler": ["@ronin/compiler@0.18.2", "", {}, "sha512-7g9PaTUiqDY2vB6kr1VhvXAftbseibM+keQ/gDc7yqDlx3vn5Iw/E7ILv6lpZbTl2kUqcDrbA5RKJc6nciym+Q=="],
 
     "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@ronin/cli": "0.3.5",
-    "@ronin/compiler": "0.18.1",
+    "@ronin/compiler": "0.18.2",
     "@ronin/syntax": "0.2.37"
   },
   "devDependencies": {


### PR DESCRIPTION
When executing a `get` query that includes both `selecting` and `using` clauses with identical fields, the generated SQL statement incorrectly attempts to query these fields twice. 
This results in a SQL statement such as `SELECT id, name, id, name ...`.

This was landed in https://github.com/ronin-co/compiler/pull/171.