### PR TITLE
Add default imports for TypeScript config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "ronin",
       "dependencies": {
-        "@ronin/cli": "0.3.5",
+        "@ronin/cli": "0.3.6",
         "@ronin/compiler": "0.18.2",
         "@ronin/syntax": "0.2.37",
       },
@@ -173,7 +173,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.40.0", "", { "os": "win32", "cpu": "x64" }, "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ=="],
 
-    "@ronin/cli": ["@ronin/cli@0.3.5", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-mrHRpEfUSnTaifvdGJClCo2Nf6OwxwOcJ/ZABx65YHeihkuE6sUNBy7zaCWCea4jZkFvQW/vlcOUrDtzBxz2xg=="],
+    "@ronin/cli": ["@ronin/cli@0.3.6", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-T+luTyM+4OTGx65s4BDVPtrLf6ZNCnkHRakdwBmfiTpL7NF8twMeOzvZHLlt0pV2DxDl4Fi4KxkuqA11ElnUQw=="],
 
     "@ronin/compiler": ["@ronin/compiler@0.18.2", "", {}, "sha512-7g9PaTUiqDY2vB6kr1VhvXAftbseibM+keQ/gDc7yqDlx3vn5Iw/E7ILv6lpZbTl2kUqcDrbA5RKJc6nciym+Q=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "node": ">=18.17.0"
   },
   "dependencies": {
-    "@ronin/cli": "0.3.5",
+    "@ronin/cli": "0.3.6",
     "@ronin/compiler": "0.18.2",
     "@ronin/syntax": "0.2.37"
   },


### PR DESCRIPTION
This change fixes a known issue with the CLI where if you do not already have `include` array in your TypeSript config, which would mean the rest of your codebase will not longer get detected by TypeScript.

This change was originally landed as part of ronin-co/cli#87.