### PR TITLE
Allow for pre-query effects

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.3.6",
-        "@ronin/compiler": "0.18.2",
-        "@ronin/syntax": "0.2.37",
+        "@ronin/compiler": "0.18.3",
+        "@ronin/syntax": "0.2.38",
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -175,11 +175,11 @@
 
     "@ronin/cli": ["@ronin/cli@0.3.6", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-T+luTyM+4OTGx65s4BDVPtrLf6ZNCnkHRakdwBmfiTpL7NF8twMeOzvZHLlt0pV2DxDl4Fi4KxkuqA11ElnUQw=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.18.2", "", {}, "sha512-7g9PaTUiqDY2vB6kr1VhvXAftbseibM+keQ/gDc7yqDlx3vn5Iw/E7ILv6lpZbTl2kUqcDrbA5RKJc6nciym+Q=="],
+    "@ronin/compiler": ["@ronin/compiler@0.18.3", "", {}, "sha512-t4Wdt/Hwz0j6ymaYNQduTyORJ7b35rAO7LAdSO+1ifQmW2C/tl4OMayaNIBrOLEbAvzdF5xwH7B4vn8pTHn3Hw=="],
 
     "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 
-    "@ronin/syntax": ["@ronin/syntax@0.2.37", "", {}, "sha512-AvCh2IfImNRFARYS/uRWBj1r7KEhULwyQ8zUdKZ/mIvJM1fdrSVRezL/5Ud6ZPCFcQRJBlky7xojWt0n/qYPWw=="],
+    "@ronin/syntax": ["@ronin/syntax@0.2.38", "", {}, "sha512-wiuCN0ukrDwmcbxWOEVffwLZKT6hI2UZ5M3jW0xan9t9PW7cgSL0ChEy9yewVYf3SKVBhuBB7x88O6dNIlAeFQ=="],
 
     "@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
 

--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
   },
   "dependencies": {
     "@ronin/cli": "0.3.6",
-    "@ronin/compiler": "0.18.2",
-    "@ronin/syntax": "0.2.37"
+    "@ronin/compiler": "0.18.3",
+    "@ronin/syntax": "0.2.38"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ import {
   type ModelField,
   type ModelIndex,
   type ModelPreset,
-  type ModelTrigger,
   QUERY_SYMBOLS,
   type Query,
   type RemoveQuery,
@@ -85,7 +84,7 @@ export const createSyntaxFactory = (
   create: DeepCallable<CreateQuery, Model>;
   alter: DeepCallable<
     AlterQuery,
-    Model | ModelField | ModelIndex | ModelTrigger | ModelPreset
+    Model | ModelField | ModelIndex | ModelPreset
   >;
   drop: DeepCallable<DropQuery, Model>;
 
@@ -149,7 +148,7 @@ export const createSyntaxFactory = (
     }),
     alter: getSyntaxProxy<
       AlterQuery,
-      Model | ModelField | ModelIndex | ModelTrigger | ModelPreset
+      Model | ModelField | ModelIndex | ModelPreset
     >({ root: `${QUERY_SYMBOLS.QUERY}.alter`, callback, replacer }),
     drop: getSyntaxProxy<DropQuery, Model>({
       root: `${QUERY_SYMBOLS.QUERY}.drop`,
@@ -198,7 +197,7 @@ export const list = factory.list as DeepCallable<ListQuery>;
 export const create = factory.create as DeepCallable<CreateQuery, Model>;
 export const alter = factory.alter as DeepCallable<
   AlterQuery,
-  Model | ModelField | ModelIndex | ModelTrigger | ModelPreset
+  Model | ModelField | ModelIndex | ModelPreset
 >;
 export const drop = factory.drop as DeepCallable<DropQuery, Model>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,10 +82,7 @@ export const createSyntaxFactory = (
 
   list: DeepCallable<ListQuery>;
   create: DeepCallable<CreateQuery, Model>;
-  alter: DeepCallable<
-    AlterQuery,
-    Model | ModelField | ModelIndex | ModelPreset
-  >;
+  alter: DeepCallable<AlterQuery, Model | ModelField | ModelIndex | ModelPreset>;
   drop: DeepCallable<DropQuery, Model>;
 
   batch: <T extends [Promise<any>, ...Array<Promise<any>>] | Array<Promise<any>>>(
@@ -146,10 +143,11 @@ export const createSyntaxFactory = (
       callback,
       replacer,
     }),
-    alter: getSyntaxProxy<
-      AlterQuery,
-      Model | ModelField | ModelIndex | ModelPreset
-    >({ root: `${QUERY_SYMBOLS.QUERY}.alter`, callback, replacer }),
+    alter: getSyntaxProxy<AlterQuery, Model | ModelField | ModelIndex | ModelPreset>({
+      root: `${QUERY_SYMBOLS.QUERY}.alter`,
+      callback,
+      replacer,
+    }),
     drop: getSyntaxProxy<DropQuery, Model>({
       root: `${QUERY_SYMBOLS.QUERY}.drop`,
       callback,

--- a/src/utils/data-hooks.ts
+++ b/src/utils/data-hooks.ts
@@ -540,7 +540,7 @@ export const runQueriesWithHooks = async <T extends ResultRecord>(
         auxiliaryForIndex: index,
       }));
 
-      queryList.splice(index + 1, 0, ...queriesToInsert);
+      queryList.splice(index, 0, ...queriesToInsert);
     }),
   );
 


### PR DESCRIPTION
This change makes it possible to run queries before other queries, within the same transaction.

Previously, we were suggesting using SQLite triggers for that, but since data hooks now have the same capabilities, we no longer need to support SQLite triggers.