### PR TITLE
Correctly set `headless` option for effects

### DIFF
--- a/tests/integration/effects.test.ts
+++ b/tests/integration/effects.test.ts
@@ -812,8 +812,8 @@ describe('effects', () => {
       },
     ]);
 
-    expect(accountEffectsOptions).toEqual({ headless: false });
-    expect(spaceEffectsOptions).toEqual({ headless: false });
+    expect(accountEffectsOptions).toEqual({ headless: true });
+    expect(spaceEffectsOptions).toEqual({ headless: true });
 
     expect(accountEffectsSpy).toHaveBeenCalled();
     expect(spaceEffectsSpy).toHaveBeenCalled();


### PR DESCRIPTION
In https://github.com/ronin-co/client/pull/123, we were performing a `Boolean()` check on a number, which means that, if the query index is `0`, it boolean would've been `false`, which is not the desired behavior.

By using only booleans and no integers, we avoid this problem entirely.