### PR TITLE
Reject invalid JSON and Blob field values

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.3.10",
-        "@ronin/compiler": "0.18.3",
+        "@ronin/compiler": "0.18.4",
         "@ronin/syntax": "0.2.38",
       },
       "devDependencies": {
@@ -175,7 +175,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.3.10", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-uoVaR2Sugok/sF7ufuFVwCkyTbXjvuNqOxuugwG9Gtf4AkjeXkEdDOqWzegKXBDqJVFIoFY8mpJBDN0Em0iOWw=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.18.3", "", {}, "sha512-t4Wdt/Hwz0j6ymaYNQduTyORJ7b35rAO7LAdSO+1ifQmW2C/tl4OMayaNIBrOLEbAvzdF5xwH7B4vn8pTHn3Hw=="],
+    "@ronin/compiler": ["@ronin/compiler@0.18.4", "", {}, "sha512-CUhTjU2dfT4F4NYFBOsmjzPEYFnAaUfuJndehww4SEIi59fX0CjV2Gy6o++zAkkzHMllr/DxBFBc5G7G2jUaVg=="],
 
     "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@ronin/cli": "0.3.10",
-    "@ronin/compiler": "0.18.3",
+    "@ronin/compiler": "0.18.4",
     "@ronin/syntax": "0.2.38"
   },
   "devDependencies": {


### PR DESCRIPTION
This change ensures that invalid values provided to fields of type "JSON" or "Blob" are correctly rejected instead of being stored in the database.

Originally, the change was applied in https://github.com/ronin-co/compiler/pull/173.