### PR TITLE
Fix missing model directory in `ronin pull`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "ronin",
       "dependencies": {
-        "@ronin/cli": "0.3.10",
+        "@ronin/cli": "0.3.11",
         "@ronin/compiler": "0.18.4",
         "@ronin/syntax": "0.2.39",
       },
@@ -173,7 +173,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.40.2", "", { "os": "win32", "cpu": "x64" }, "sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA=="],
 
-    "@ronin/cli": ["@ronin/cli@0.3.10", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-uoVaR2Sugok/sF7ufuFVwCkyTbXjvuNqOxuugwG9Gtf4AkjeXkEdDOqWzegKXBDqJVFIoFY8mpJBDN0Em0iOWw=="],
+    "@ronin/cli": ["@ronin/cli@0.3.11", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-Qb5RNUwVEcIvbbZIcX9oRVGaVP9SCsYscb8A5E4nZMF5resXSy1XlblDOxIn2vVOkTiwXwZ/o/ZyEaZobrEbtg=="],
 
     "@ronin/compiler": ["@ronin/compiler@0.18.4", "", {}, "sha512-CUhTjU2dfT4F4NYFBOsmjzPEYFnAaUfuJndehww4SEIi59fX0CjV2Gy6o++zAkkzHMllr/DxBFBc5G7G2jUaVg=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "node": ">=18.17.0"
   },
   "dependencies": {
-    "@ronin/cli": "0.3.10",
+    "@ronin/cli": "0.3.11",
     "@ronin/compiler": "0.18.4",
     "@ronin/syntax": "0.2.39"
   },


### PR DESCRIPTION
This pull request fixes the `ronin pull` command by checking for and creating the model definition directory if it doesn't exist, preventing crashes. Additionally, it ensures that the space ID is correctly passed and utilised during the pull process.

This was landed in https://github.com/ronin-co/cli/pull/93.