### PR TITLE
Allow empty value for JSON and Blob fields

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.3.11",
-        "@ronin/compiler": "0.18.4",
+        "@ronin/compiler": "0.18.5",
         "@ronin/syntax": "0.2.39",
       },
       "devDependencies": {
@@ -175,7 +175,7 @@
 
     "@ronin/cli": ["@ronin/cli@0.3.11", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-Qb5RNUwVEcIvbbZIcX9oRVGaVP9SCsYscb8A5E4nZMF5resXSy1XlblDOxIn2vVOkTiwXwZ/o/ZyEaZobrEbtg=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.18.4", "", {}, "sha512-CUhTjU2dfT4F4NYFBOsmjzPEYFnAaUfuJndehww4SEIi59fX0CjV2Gy6o++zAkkzHMllr/DxBFBc5G7G2jUaVg=="],
+    "@ronin/compiler": ["@ronin/compiler@0.18.5", "", {}, "sha512-RgWsaJHbAT92qRzLRbqwJiyyuK3rq8IadwIT3zc8+vVZV/P2SL8WLVNIt9+uaezfidRhLzZazzRSwwCTbFyLrA=="],
 
     "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@ronin/cli": "0.3.11",
-    "@ronin/compiler": "0.18.4",
+    "@ronin/compiler": "0.18.5",
     "@ronin/syntax": "0.2.39"
   },
   "devDependencies": {


### PR DESCRIPTION
This change ensures that empty values are accepted for JSON and Blob fields.

Originally, this change was landed in https://github.com/ronin-co/compiler/pull/174.