### PR TITLE
Expose client to triggers

### DIFF
--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -313,7 +313,7 @@ const invokeTriggers = async (
   /** The result of a query provided by the trigger. */
   result?: FormattedResults<unknown>[number] | symbol;
 }> => {
-  const { triggers } = options;
+  const { triggers, database } = options;
   const { query } = definition;
 
   const queryType = Object.keys(query)[0] as QueryType;
@@ -347,7 +347,7 @@ const invokeTriggers = async (
   //
   // If the triggers are *not* being executed for a custom database, the trigger file name
   // matches the model that is being addressed by the query.
-  const triggerFile = options.database ? 'sink' : queryModelDashed;
+  const triggerFile = database ? 'sink' : queryModelDashed;
   const triggersForModel = triggers[triggerFile];
   const triggerName = getMethodName(triggerType, queryType);
 
@@ -369,9 +369,7 @@ const invokeTriggers = async (
     const implicit = definition.implicit ?? false;
     const trigger = triggersForModel[triggerName as keyof typeof triggersForModel];
     const triggerOptions =
-      triggerFile === 'sink'
-        ? { model: queryModel, database: options.database, implicit }
-        : { implicit };
+      triggerFile === 'sink' ? { model: queryModel, database, implicit } : { implicit };
 
     // For triggers of type "following" (such as `followingAdd`), we want to pass
     // special function arguments that contain the value of the affected records


### PR DESCRIPTION
This change exposes a new option called `client` to trigger functions, which allows for running nested queries from within triggers that re-use the same client configuration as the top-level query:

```typescript
export const set: SetTrigger = async (query, multiple, options) => {
  const { get } = options.client;
  const records = await get.accounts();
  ...

  return query;
}
```