### PR TITLE
Removed `asyncContext` config option

### DIFF
--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,5 +1,3 @@
-import type { AsyncLocalStorage } from 'node:async_hooks';
-
 import type { Triggers } from '@/src/utils/triggers';
 
 import type { Model, Result, ResultRecord } from '@ronin/compiler';
@@ -30,13 +28,6 @@ export interface QueryHandlerOptions {
    * an edge runtime, this option is required.
    */
   waitUntil?: (promise: Promise<unknown>) => void;
-
-  /**
-   * Allows for preventing recursions when running queries from triggers
-   * provided with the `triggers` option. If the `triggers` option is provided, this
-   * option is required.
-   */
-  asyncContext?: AsyncLocalStorage<any>;
 
   /**
    * If the query should be run for a specific database within your space, you may

--- a/tests/integration/edge.test.ts
+++ b/tests/integration/edge.test.ts
@@ -1,5 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-
 import { describe, expect, spyOn, test } from 'bun:test';
 
 import createSyntaxFactory from '@/src/index';
@@ -43,7 +41,6 @@ describe('edge runtime', () => {
           // @ts-expect-error - We are deliberately causing an error.
           add: () => undefined,
         },
-        asyncContext: new AsyncLocalStorage(),
       });
 
       await factory.add.account({ with: { handle: 'leo' } });
@@ -105,7 +102,6 @@ describe('edge runtime', () => {
         waitUntil: (promise) => {
           promisesToAwait.push(promise);
         },
-        asyncContext: new AsyncLocalStorage(),
       },
     );
 
@@ -161,7 +157,6 @@ describe('edge runtime', () => {
         waitUntil: (promise) => {
           promisesToAwait.push(promise);
         },
-        asyncContext: new AsyncLocalStorage(),
       },
     );
 
@@ -213,7 +208,6 @@ describe('edge runtime', () => {
         waitUntil: (promise) => {
           promisesToAwait.push(promise);
         },
-        asyncContext: new AsyncLocalStorage(),
       },
     );
 

--- a/tests/integration/triggers.test.ts
+++ b/tests/integration/triggers.test.ts
@@ -1,5 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-
 import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
 import { createSyntaxFactory } from '@/src/index';
@@ -58,7 +56,6 @@ describe('triggers', () => {
           resolvingGet: mockTrigger as any,
         },
       },
-      asyncContext: new AsyncLocalStorage(),
     });
 
     expect(mockTrigger).toHaveBeenCalled();
@@ -86,7 +83,6 @@ describe('triggers', () => {
           },
         },
       },
-      asyncContext: new AsyncLocalStorage(),
     });
 
     await get.account.with.handle('juri');
@@ -118,7 +114,6 @@ describe('triggers', () => {
           },
         },
       },
-      asyncContext: new AsyncLocalStorage(),
     });
 
     await get.account.with.handle('elaine');
@@ -149,7 +144,6 @@ describe('triggers', () => {
           },
         },
       },
-      asyncContext: new AsyncLocalStorage(),
     }));
 
     await get.account.with.handle('juri');
@@ -188,7 +182,6 @@ describe('triggers', () => {
           },
         },
       },
-      asyncContext: new AsyncLocalStorage(),
     });
 
     const schema = await get.schema.with.id('1');
@@ -237,7 +230,6 @@ describe('triggers', () => {
           },
         },
       },
-      asyncContext: new AsyncLocalStorage(),
     });
 
     const model = await create.model({
@@ -313,7 +305,6 @@ describe('triggers', () => {
           },
         },
       },
-      asyncContext: new AsyncLocalStorage(),
     });
 
     await (alter as unknown as (details: object) => unknown)({
@@ -383,7 +374,6 @@ describe('triggers', () => {
           },
         },
       },
-      asyncContext: new AsyncLocalStorage(),
     });
 
     const model = await drop.model('account' as Parameters<typeof drop.model>[0]);
@@ -433,7 +423,6 @@ describe('triggers', () => {
           },
         },
       },
-      asyncContext: new AsyncLocalStorage(),
     });
 
     const account = await remove.account({
@@ -497,7 +486,6 @@ describe('triggers', () => {
           },
         },
       },
-      asyncContext: new AsyncLocalStorage(),
     });
 
     const accounts = (await set.accounts({
@@ -562,7 +550,6 @@ describe('triggers', () => {
           },
         },
       },
-      asyncContext: new AsyncLocalStorage(),
     });
 
     const result = await batch(() => [
@@ -665,7 +652,6 @@ describe('triggers', () => {
             },
           },
         },
-        asyncContext: new AsyncLocalStorage(),
       },
     );
 
@@ -783,7 +769,6 @@ describe('triggers', () => {
         space: spaceTriggers,
       },
       fetch: mockFetchNew,
-      asyncContext: new AsyncLocalStorage(),
     });
 
     // We're using a batch to be able to check whether the results of the queries
@@ -937,7 +922,6 @@ describe('triggers', () => {
         app: appTriggers,
       },
       fetch: mockFetchNew,
-      asyncContext: new AsyncLocalStorage(),
     });
 
     // We're using a batch to be able to check whether the results of the queries


### PR DESCRIPTION
Since the `asyncContext` config option is no longer being used, we can remove it.