### PR TITLE
Correctly throw error about token

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -164,6 +164,32 @@ export async function runQueriesWithStorageAndTriggers<T extends ResultRecord>(
   queries: Array<Query> | Record<string, Array<Query>>,
   options: QueryHandlerOptions = {},
 ): Promise<FormattedResults<T> | Record<string, FormattedResults<T>>> {
+  if (!options.token && typeof process !== 'undefined') {
+    const token =
+      typeof process?.env !== 'undefined'
+        ? process.env.RONIN_TOKEN
+        : typeof import.meta?.env !== 'undefined'
+          ? import.meta.env.RONIN_TOKEN
+          : undefined;
+
+    if (!token || token === 'undefined') {
+      const message =
+        'Please specify the `RONIN_TOKEN` environment variable' +
+        ' or set the `token` option when invoking RONIN.';
+
+      throw new Error(message);
+    }
+
+    options.token = token;
+  }
+
+  if (!options.token) {
+    let message = 'When invoking RONIN from an edge runtime, the';
+    message += ' `token` option must be set.';
+
+    throw new Error(message);
+  }
+
   const singleDatabase = Array.isArray(queries);
   const normalizedQueries = singleDatabase ? { default: queries } : queries;
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -49,7 +49,7 @@ export const runQueries = async <T extends ResultRecord>(
   // Ensure that a token is present. We must only perform this check if there is a
   // guarantee that actual queries must be executed. For example, if the client is
   // initialized with triggers that run all the queries using a different data source,
-  // we don't want to ensure that a token is present.
+  // we don't want to require a token.
   validateToken(options);
 
   let hasWriteQuery: boolean | null = null;

--- a/src/utils/handlers.ts
+++ b/src/utils/handlers.ts
@@ -26,34 +26,6 @@ export const queriesHandler = async (
   queries: Array<Query> | { statements: Array<Statement> },
   options: QueryHandlerOptions = {},
 ) => {
-  if (!options.token && typeof process !== 'undefined') {
-    const token =
-      typeof process?.env !== 'undefined'
-        ? process.env.RONIN_TOKEN
-        : typeof import.meta?.env !== 'undefined'
-          ? import.meta.env.RONIN_TOKEN
-          : undefined;
-
-    if (!token || token === 'undefined') {
-      const message =
-        'Please specify the `RONIN_TOKEN` environment variable' +
-        ' or set the `token` option when invoking RONIN.';
-
-      throw new Error(message);
-    }
-
-    options.token = token;
-  }
-
-  const token = options.token;
-
-  if (!token) {
-    let message = 'When invoking RONIN from an edge runtime, the';
-    message += ' `token` option must be set.';
-
-    throw new Error(message);
-  }
-
   if ('statements' in queries) {
     const results = await runQueries(
       queries.statements.map((statement) => ({ statement })),

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -63,3 +63,38 @@ export const mergeOptions = (
     return acc;
   }, {});
 };
+
+/**
+ * Validates the presence of a token in the provided options.
+ *
+ * @param options - Options for the query handler, which may include a token.
+ *
+ * @returns Nothing if the token is valid, otherwise throws an error.
+ */
+export const validateToken = (options: QueryHandlerOptions = {}) => {
+  if (!options.token && typeof process !== 'undefined') {
+    const token =
+      typeof process?.env !== 'undefined'
+        ? process.env.RONIN_TOKEN
+        : typeof import.meta?.env !== 'undefined'
+          ? import.meta.env.RONIN_TOKEN
+          : undefined;
+
+    if (!token || token === 'undefined') {
+      const message =
+        'Please specify the `RONIN_TOKEN` environment variable' +
+        ' or set the `token` option when invoking RONIN.';
+
+      throw new Error(message);
+    }
+
+    options.token = token;
+  }
+
+  if (!options.token) {
+    let message = 'When invoking RONIN from an edge runtime, the';
+    message += ' `token` option must be set.';
+
+    throw new Error(message);
+  }
+};

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -10,7 +10,7 @@ import type {
   RecursivePartial,
 } from '@/src/types/utils';
 import { WRITE_QUERY_TYPES } from '@/src/utils/constants';
-import { toDashCase } from '@/src/utils/helpers';
+import { toDashCase, validateToken } from '@/src/utils/helpers';
 import {
   type CombinedInstructions,
   DDL_QUERY_TYPES,

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -10,7 +10,7 @@ import type {
   RecursivePartial,
 } from '@/src/types/utils';
 import { WRITE_QUERY_TYPES } from '@/src/utils/constants';
-import { toDashCase, validateToken } from '@/src/utils/helpers';
+import { toDashCase } from '@/src/utils/helpers';
 import {
   type CombinedInstructions,
   DDL_QUERY_TYPES,

--- a/tests/integration/edge.test.ts
+++ b/tests/integration/edge.test.ts
@@ -102,6 +102,7 @@ describe('edge runtime', () => {
         waitUntil: (promise) => {
           promisesToAwait.push(promise);
         },
+        token: 'supertoken',
       },
     );
 
@@ -157,6 +158,7 @@ describe('edge runtime', () => {
         waitUntil: (promise) => {
           promisesToAwait.push(promise);
         },
+        token: 'supertoken',
       },
     );
 
@@ -208,6 +210,7 @@ describe('edge runtime', () => {
         waitUntil: (promise) => {
           promisesToAwait.push(promise);
         },
+        token: 'supertoken',
       },
     );
 


### PR DESCRIPTION
This change ensures that the client throws an error if no token was provided, even if only the client's data fetching utilities are used, instead of the whole client.