### PR TITLE
Allow for requiring triggers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "ronin",
       "dependencies": {
         "@ronin/cli": "0.3.19",
-        "@ronin/compiler": "0.18.8",
+        "@ronin/compiler": "0.18.9",
         "@ronin/engine": "0.1.23",
         "@ronin/syntax": "0.2.43",
       },
@@ -178,7 +178,7 @@
 
     "@ronin/codegen": ["@ronin/codegen@1.7.4", "", { "dependencies": { "typescript": "5.7.3" } }, "sha512-snvGHHjiy66mcVm6KG3lHXIq3U/yze1SgNoSZzrKq9vHTG4thkulbnXOXRWjagnFH2HPv0xcQQNW7a8VT0XjZg=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.18.8", "", { "peerDependencies": { "@ronin/engine": ">=0.1.23" } }, "sha512-9IvxXVmaoT+5ECsUBTkIY6N2GdC8o3HpmfpHYjyMTDXYhg0mrxg8Jgf1cisg/PxFyoOTOr5fkMzZ7nyueH+KvA=="],
+    "@ronin/compiler": ["@ronin/compiler@0.18.9", "", { "peerDependencies": { "@ronin/engine": ">=0.1.23" } }, "sha512-6h1YGdpcD/hUlrS4Mm9NvG+MlWcaPZ/+eaALSvxBXxxWb4dWcwtrtAU9/X3eZusSOa3MT6fbP3i1vDLdLWo/JA=="],
 
     "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@ronin/cli": "0.3.19",
-    "@ronin/compiler": "0.18.8",
+    "@ronin/compiler": "0.18.9",
     "@ronin/engine": "0.1.23",
     "@ronin/syntax": "0.2.43"
   },

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -9,6 +9,11 @@ export interface QueryHandlerOptions {
   triggers?: Triggers;
 
   /**
+   * Specific query types to require "during" triggers for.
+   */
+  requireTriggers?: 'all' | 'write' | 'read';
+
+  /**
    * Token used to authenticate against RONIN. By default,
    * `process.env.RONIN_TOKEN` will be used.
    */

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -9,7 +9,7 @@ export interface QueryHandlerOptions {
   triggers?: Triggers;
 
   /**
-   * Specific query types to require "during" triggers for.
+   * Specific query types for which "during" triggers should be required.
    */
   requireTriggers?: 'all' | 'write' | 'read';
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -98,3 +98,27 @@ export const validateToken = (options: QueryHandlerOptions = {}) => {
     throw new Error(message);
   }
 };
+
+/**
+ * Omit a list of properties from an object returning a new object with the properties
+ * that remain.
+ *
+ * @param obj — The object to omit properties from.
+ * @param keys - The keys of the properties that should be omitted.
+ *
+ * @returns The updated object.
+ */
+export const omit = <T, TKeys extends keyof T>(
+  obj: T,
+  keys: Array<TKeys>,
+): Omit<T, TKeys> => {
+  if (!obj) return {} as Omit<T, TKeys>;
+  if (!keys || keys.length === 0) return obj as Omit<T, TKeys>;
+  return keys.reduce(
+    (acc, key) => {
+      delete acc[key];
+      return acc;
+    },
+    { ...obj },
+  );
+};

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -114,6 +114,7 @@ export const omit = <T, TKeys extends keyof T>(
 ): Omit<T, TKeys> => {
   if (!obj) return {} as Omit<T, TKeys>;
   if (!keys || keys.length === 0) return obj as Omit<T, TKeys>;
+
   return keys.reduce(
     (acc, key) => {
       delete acc[key];

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -10,7 +10,7 @@ import type {
   RecursivePartial,
 } from '@/src/types/utils';
 import { WRITE_QUERY_TYPES } from '@/src/utils/constants';
-import { toDashCase } from '@/src/utils/helpers';
+import { omit, toDashCase } from '@/src/utils/helpers';
 import {
   type CombinedInstructions,
   DDL_QUERY_TYPES,
@@ -479,7 +479,10 @@ export const runQueriesWithTriggers = async <T extends ResultRecord>(
 
   // If triggers were provided, intialize a new client instance that can be used for
   // nested queries within triggers.
-  const client = createSyntaxFactory(options);
+  //
+  // We are stripping the `requireTriggers` option, because no triggers should be
+  // required for queries that are nested into triggers.
+  const client = createSyntaxFactory(omit(options, ['requireTriggers']));
 
   if (typeof process === 'undefined' && !waitUntil) {
     let message = 'In the case that the "ronin" package receives a value for';

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -541,7 +541,7 @@ export const runQueriesWithTriggers = async <T extends ResultRecord>(
 
       if (requireTriggers) {
         const queryType = Object.keys(query)[0] as QueryType;
-        const requiredTypes =
+        const requiredTypes: ReadonlyArray<QueryType> =
           requireTriggers === 'read'
             ? QUERY_TYPES_READ
             : requireTriggers === 'write'

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -539,6 +539,8 @@ export const runQueriesWithTriggers = async <T extends ResultRecord>(
         return;
       }
 
+      // If "during" triggers are required for the query type of the current query,
+      // we want to throw an error to prevent the query from being executed.
       if (requireTriggers) {
         const queryType = Object.keys(query)[0] as QueryType;
         const requiredTypes: ReadonlyArray<QueryType> =

--- a/tests/integration/triggers.test.ts
+++ b/tests/integration/triggers.test.ts
@@ -958,4 +958,60 @@ describe('triggers', () => {
       }),
     );
   });
+
+  test('run queries with triggers required for all queries', async () => {
+    const { get, remove } = createSyntaxFactory({
+      // biome-ignore lint/suspicious/useAwait: We need this to satisfy the types.
+      fetch: async () => {
+        return Response.json({ results: [] });
+      },
+      requireTriggers: 'all',
+    });
+
+    expect(get.accounts()).rejects.toThrow(
+      'Please define "during" triggers for the provided queries.',
+    );
+
+    expect(remove.account.with.handle('elaine')).rejects.toThrow(
+      'Please define "during" triggers for the provided queries.',
+    );
+  });
+
+  test('run queries with triggers required for read queries', async () => {
+    const { get } = createSyntaxFactory({
+      // biome-ignore lint/suspicious/useAwait: We need this to satisfy the types.
+      fetch: async () => {
+        return Response.json({ results: [] });
+      },
+      requireTriggers: 'read',
+      triggers: {
+        team: {
+          get: (query) => query,
+        },
+      },
+    });
+
+    expect(get.accounts()).rejects.toThrow(
+      'Please define "during" triggers for the provided read queries.',
+    );
+  });
+
+  test('run queries with triggers required for write queries', async () => {
+    const { remove } = createSyntaxFactory({
+      // biome-ignore lint/suspicious/useAwait: We need this to satisfy the types.
+      fetch: async () => {
+        return Response.json({ results: [] });
+      },
+      requireTriggers: 'write',
+      triggers: {
+        team: {
+          get: (query) => query,
+        },
+      },
+    });
+
+    expect(remove.account.with.handle('elaine')).rejects.toThrow(
+      'Please define "during" triggers for the provided write queries.',
+    );
+  });
 });


### PR DESCRIPTION
This change adds a new option called `requireTriggers`, which allows for throwing an error if triggers are not provided.