### PR TITLE
Ensure correct error types

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,6 +1,9 @@
+import type { CompilerError } from '@ronin/compiler';
+
 interface ClientErrorDetails {
   message: string;
-  code: 'JSON_PARSE_ERROR' | 'TRIGGER_REQUIRED';
+  // Since compiler errors might get returned by the platform, we have to add them here.
+  code: 'JSON_PARSE_ERROR' | 'TRIGGER_REQUIRED' | CompilerError['code'];
 }
 
 export class ClientError extends Error {


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/client/pull/144 and ensures that the types of `ClientError` are correct.