### PR TITLE
Correctly set `implicit` option for triggers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,9 @@ import type { Model } from '@ronin/syntax/schema';
  *
  * @param options - An optional object of options for the query execution.
  *
- * Alternatively, a function that returns the object may be provided instead,
- * which is useful for cases in which the config must be generated dynamically
- * whenever a query is executed.
+ * Alternatively, a function that returns the object may be provided instead, which is
+ * useful for cases in which the config must be generated dynamically whenever a query
+ * is executed.
  *
  * @returns An object with methods for generating and executing different types
  * of queries.

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -39,6 +39,15 @@ export interface QueryHandlerOptions {
    * provide the desired database name here.
    */
   database?: string;
+
+  /**
+   * Sets the `implicit` option received by triggers, allowing for indicating whether the
+   * client is being invoked from within triggers.
+   *
+   * In order to automatically resume the configuration of the client, it is highly
+   * recommended to use the client provided in the `options.client` argument for triggers.
+   */
+  implicit?: boolean;
 }
 
 /**


### PR DESCRIPTION
This change ensures that, when someone uses the TypeScript client provided in the `options.client` argument to triggers, the triggers invoked for the queries of that client are correctly marked as `implicit`.